### PR TITLE
Post-release polish: de-slop audit of the shipped 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,9 @@ validated live on all three. 73 commits (PR [#23](https://github.com/SiEPIC/gds_
   port to the superstrate (F4).
 - 646 lines of dead code removed (write-only field-monitor plumbing,
   uncalled log-metrics chains, legacy `sparam`/`s_parameters`).
+- Example `09_smatrix` no longer requires the optional h5py on a clean
+  install; library modules log instead of printing; shipped docstrings
+  scrubbed of internal project references (pre-PyPI polish audit).
 
 ### Removed
 - Fake-coverage test that exec-compiled `pass` statements to inflate

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gds_fdtd
 
-![alternative text](/docs/logo.png)
+![gds_fdtd logo](docs/logo.png)
 
 [![CI](https://github.com/SiEPIC/gds_fdtd/actions/workflows/ci.yml/badge.svg)](https://github.com/SiEPIC/gds_fdtd/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/siepic/gds_fdtd/branch/main/graph/badge.svg)](https://codecov.io/gh/siepic/gds_fdtd)
@@ -32,7 +32,7 @@ smatrix = solver.run()
 - **Layout ingestion:** raw GDS via KLayout with SiEPIC pin/devrec conventions, [SiEPIC](https://github.com/SiEPIC/SiEPIC-Tools) PDK cells, and [gdsfactory](https://github.com/gdsfactory/gdsfactory) (>= 9) components — ports auto-detected, never hand-placed.
 - **Validated technology files:** the layer stack is a pydantic-validated YAML (bad files fail with the offending key named). Materials can carry per-solver entries or a neutral [refractiveindex.info](https://refractiveindex.info) reference (`rii: {shelf, book, page}`), resolved offline from a local database copy.
 - **Canonical S-matrix:** one `SMatrix` type with NaN-aware partial matrices, reciprocity/passivity/power-balance checks, and I/O to Lumerical INTERCONNECT `.dat`, Touchstone `.sNp` (scikit-rf compatible), HDF5/npz, plus plotting.
-- **Cross-validated engines** (see [SOLVER_STATUS.md](SOLVER_STATUS.md) for per-engine last-verified dates): the tidy3d (>= 2.11, cloud) and Lumerical (2024/2025, local) adapters were validated live against each other on identical geometry (< 0.15 dB agreement, locked into CI via recorded artifacts). [beamz](https://github.com/beamzorg/beamz) provides a fully open-source, zero-cost local engine (JAX, CPU/GPU).
+- **Cross-validated engines** (see [SOLVER_STATUS.md](SOLVER_STATUS.md) for per-engine last-verified dates): the tidy3d (>= 2.11, cloud) and Lumerical (2024/2025, local) adapters were validated live against each other on identical geometry — within **0.0033 dB**, with the free [beamz](https://github.com/beamzorg/beamz) engine (JAX, CPU/GPU) inside 0.052 dB of both; the agreement is locked into CI via recorded artifacts.
 - **Multimode/dual-polarization** simulations on the engines that support them (tidy3d, Lumerical).
 - **Serializable jobs + CLI:** every simulation is a JSON `JobSpec`; `gds-fdtd validate|build|estimate|run|convert|solvers` drives it from the shell, and `SubprocessBackend` runs sweeps crash-isolated and in parallel. Secrets stay in the environment — job files are safe to ship to a cluster or cloud runner ([docs/remote_compute.md](docs/remote_compute.md)).
 - **Convergence sweeps, caching, cross-solver validation:** `convergence.sweep()` steps any `SimulationSpec` field and recommends the converged value; `run_cached()` hashes the full job (geometry + technology + spec + engine version) so repeat runs are free; `validation.validate_across()` quantifies worst-case |ΔS| between engines on the same job.
@@ -107,7 +107,7 @@ This will install additional tools like `pytest` and `coverage` for testing.
 ### Requirements
 
 - Python ≥ 3.11
-- Runtime deps: numpy, matplotlib, shapely, PyYAML, klayout
+- Runtime deps: numpy, matplotlib, shapely, PyYAML, klayout, pydantic, pydantic-settings
 
 
 ### Running tests

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![PyPI](https://img.shields.io/pypi/v/gds_fdtd)](https://pypi.org/project/gds-fdtd/)
 [![Python](https://img.shields.io/pypi/pyversions/gds_fdtd)](https://pypi.org/project/gds-fdtd/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/SiEPIC/gds_fdtd/badge)](https://scorecard.dev/viewer/?uri=github.com/SiEPIC/gds_fdtd)
 
 **gds_fdtd** turns a photonic chip layout (GDS) into ready-to-run 3D FDTD simulations on the engine of your choice, and returns standardized S-parameters. EDA-agnostic on the front (KLayout/SiEPIC, gdsfactory), solver-agnostic on the back — one component, one technology file, any engine:
 

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -1,53 +1,81 @@
 Architecture Overview
 =====================
 
-Here's how the different parts of ``gds_fdtd`` work together to run FDTD simulations.
+GDS in, S-parameters out — with every engine behind one contract.
 
-Main Modules
+.. code-block:: text
+
+    layout (GDS / gdsfactory / SiEPIC)
+        │  lyprocessor · layout.gdsfactory        ports auto-detected
+        ▼
+    Component  ─────────  Technology (YAML, schema v2: named materials)
+        │
+        ▼
+    Solver ABC (solvers.base) ── registry + entry points
+        │        validate() · build() · estimate()   [offline, free]
+        │        run()                                [the only spending step]
+        ▼
+    SMatrix ── checks (reciprocity/passivity) · .dat / Touchstone / HDF5 / npz
+        │
+        ▼
+    plotting · convergence.sweep · validation.validate_across · caching
+
+Core modules
 ------------
 
-``core``
-    Contains the basic data structures and functions that everything else uses.
-    This is where ports, components, and geometry are defined.
+``geometry``
+    ``Component``, ``Structure`` (flat, role-tagged: device / substrate /
+    superstrate), ``Port`` (with port-extension stubs through the boundary),
+    ``Region``.
 
-``lyprocessor``
-    Takes GDS files and turns them into something the simulation can understand.
-    Uses KLayout to read the layout files and extract the shapes.
+``technology`` / ``materials.rii``
+    Pydantic-validated technology files. Schema v2 defines named materials
+    once (neutral ``nk``/``rii`` + per-engine hints) and layers reference
+    them; ``gds-fdtd convert-tech`` migrates v1 files.
 
-``simprocessor``
-    Puts everything together. Takes your technology file and GDS layout
-    and creates a simulation setup.
+``lyprocessor`` / ``simprocessor`` / ``layout.gdsfactory``
+    GDS loading via KLayout (SiEPIC pin conventions), component assembly,
+    and gdsfactory (>= 9) conversion.
 
-``sparams``
-    Handles S-parameter calculations after the simulation runs. Can export
-    results to different file formats.
+``spec``
+    ``SimulationSpec`` — every numeric simulation setting, validated, in
+    package-wide units (µm / degrees / Hz).
 
-``logging_config``
-    Keeps track of what happens during simulations. Writes detailed logs
-    to files so you can debug problems.
+``smatrix`` / ``sparams``
+    The canonical ``SMatrix`` container plus the Lumerical-format ``.dat``
+    reader/writer it interoperates with.
 
-How the Solvers Work
---------------------
+Solver layer
+------------
 
-``solver`` (Base Class)
-    The foundation that both Tidy3D and Lumerical solvers build on.
-    Handles common tasks like port setup and parameter checking.
+``solvers.base``
+    The ``Solver`` ABC and registry. Constructors are cheap and pure;
+    ``validate``/``build``/``estimate`` are offline; only ``run()`` spends.
+    Third-party engines register via the ``gds_fdtd.solvers`` entry-point
+    group (see :doc:`adding_a_solver`).
 
-``solver_tidy3d``
-    Runs simulations on Tidy3D's cloud platform. Uses their ComponentModeler
-    to get accurate S-parameters. Works with multiple polarizations.
+``solvers.tidy3d`` / ``solvers.lumerical`` / ``solvers.beamz``
+    The engine adapters. The tidy3d and Lumerical adapters wrap the
+    pre-0.5 implementation modules (``solver_tidy3d`` / ``solver_lumerical``,
+    deprecated as public API, removal at v1.0).
 
-``solver_lumerical``
-    Interfaces with Lumerical FDTD on your local machine or cluster.
-    Can use GPU acceleration and handles complex layer stacks.
+``grid`` / ``modes`` / ``extraction``
+    The kernel-engine pipeline: permittivity rasterization with sub-pixel
+    averaging, local mode solving, and bidirectional mode-overlap
+    extraction — for engines that only accept raw permittivity arrays.
 
-What Makes It Useful
---------------------
+Orchestration
+-------------
 
-The package is built so you can easily switch between different solvers without rewriting your simulation setup. Both Tidy3D and Lumerical solvers use the same interface, so your code stays mostly the same.
+``convergence`` / ``caching`` / ``validation``
+    Field sweeps with converged-value recommendation; job-hash result
+    caching (repeat runs are free); cross-engine agreement reports.
 
-You can run simulations with both TE and TM polarizations at once, which is handy for analyzing things like polarization beam splitters or mode converters.
+``execution`` / ``cli``
+    Serializable ``JobSpec`` + local/subprocess backends and the
+    ``gds-fdtd`` command-line interface — the remote-compute surface
+    (see :doc:`remote_compute`).
 
-Everything gets logged automatically, so when something goes wrong (and it will), you have detailed information to figure out what happened.
-
-The examples show you how to use all these pieces together for real photonic device simulations.
+``errors`` / ``settings`` / ``logging_config``
+    One exception hierarchy (``GdsFdtdError``), ``GDS_FDTD_*`` environment
+    configuration, and package-scoped logging (text or JSON lines).

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,39 +1,49 @@
 Examples
 ========
 
-The ``examples`` directory contains a variety of small scripts that
-show how to use the library with different simulation engines and
-workflows.  Each script can be executed directly with Python once the
-package and optional dependencies are installed.
+The ``examples/`` directory covers every feature; each script runs directly
+with Python. Scripts follow one standardized flow: geometry plot (ports +
+FDTD region + port extensions) → offline setup (free) → S-parameters →
+field profile.
 
-.. list-table:: Available examples
+.. list-table::
    :header-rows: 1
 
    * - Directory
-     - Description
-
+     - Shows
    * - ``01_basics``
-     - Simple directional coupler and crossing simulations using
-       :mod:`tidy3d`.
-   * - ``02_multilayer_device``
-     - Multilayer structures and more complex port definitions.
-   * - ``03_import_technology``
-     - Importing technology YAML files and performing convergence
-       studies.
-   * - ``04_dual_polarization``
-     - Running a Bragg grating with both TE and TM polarisations.
+     - First contact: load & inspect any GDS with no engine installed
+       (``01b``); the free offline setup flow on tidy3d (``01a``).
+   * - ``02_lumerical``
+     - The standard flow on Lumerical FDTD; ``02b`` is a mesh-convergence
+       study — identical code to ``03b`` except the engine string.
+   * - ``03_tidy3d``
+     - The same flow on the tidy3d cloud (``03a`` with curated
+       thru/crosstalk/reflection plots); ``03b`` mesh convergence.
+   * - ``04_solvers``
+     - The engine-agnostic registry (``04a``); convergence sweeps + job
+       caching (``04b``); three-engine cross-validation on recorded real
+       results — runs offline (``04c``).
    * - ``05_gdsfactory``
-     - Integration with :mod:`gdsfactory` component definitions.
-   * - ``06_lumerical``
-     - Exporting structures to Lumerical's FDTD solver.
+     - gdsfactory (>= 9) components into any solver.
+   * - ``06_beamz``
+     - The free, open-source engine: straight (``06a``), S-bend
+       (``06b``), and a zero-cost mesh-convergence study (``06c``).
    * - ``07_prefab``
-     - Example workflow with the PreFab lithography package.
+     - Lithography-predicted geometry via PreFab.
    * - ``08_siepic``
-     - Utilities for the SiEPIC ecosystem.
+     - SiEPIC EBeam PDK cells on tidy3d / Lumerical.
+   * - ``09_smatrix``
+     - SMatrix I/O on recorded real data: .dat, Touchstone, npz/HDF5,
+       physics checks, plotting — fully offline.
+   * - ``10_materials``
+     - Validated technology YAML (schema v2, named materials) +
+       refractiveindex.info sources.
 
-To run an example simply execute for instance::
+Run any of them like::
 
-    python examples/01_basics/01a_directional_coupler_tidy3d.py
+    python examples/04_solvers/04c_cross_solver_validation.py
 
-Each script is well commented and mirrors the high level API provided by
-``gds_fdtd``.
+Examples that call ``solver.run()`` on tidy3d spend FlexCredits and say so
+in their docstrings; Lumerical examples need a local license; every beamz
+example is free.

--- a/examples/09_smatrix/09a_smatrix_io.py
+++ b/examples/09_smatrix/09a_smatrix_io.py
@@ -24,14 +24,21 @@ if __name__ == "__main__":
     print("reciprocal:", sm.is_reciprocal(atol=0.05))
     print("passive:", sm.is_passive(atol=0.02))
 
-    # exports: Touchstone (industry standard), HDF5, .dat
-    sm.to_touchstone(os.path.join(here, "escalator.s2p"))  # scikit-rf readable
-    sm.to_hdf5(os.path.join(here, "escalator.h5"))
-    print("wrote escalator.s2p / escalator.h5")
+    # exports: Touchstone (industry standard), npz, .dat — outputs land in CWD
+    sm.to_touchstone("escalator.s2p")  # scikit-rf readable
+    sm.to_npz("escalator.npz")
+    print("wrote escalator.s2p / escalator.npz")
+
+    # HDF5 needs the optional h5py (pip install h5py)
+    try:
+        sm.to_hdf5("escalator.h5")
+        print("wrote escalator.h5")
+    except ImportError as e:
+        print(f"skipped HDF5 export: {e}")
 
     # plotting (matplotlib, lazy import)
     from gds_fdtd.plotting import plot_smatrix
 
     fig, ax = plot_smatrix(sm, kind="db")
-    fig.savefig(os.path.join(here, "escalator_sparams.png"), dpi=150)
+    fig.savefig("escalator_sparams.png", dpi=150)
     print("wrote escalator_sparams.png")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 [project]
 name            = "gds_fdtd"
 dynamic         = ["version"]
-description     = "Minimalist utilities for photonic FDTD workflows."
+description     = "Solver-agnostic 3D FDTD for photonic layouts: GDS in, S-parameters out - tidy3d, Lumerical, or beamz behind one API."
 authors         = [{ name = "Mustafa Hammood", email = "mustafa@siepic.com" }]
 license         = { text = "MIT" }
 readme          = { file = "README.md", content-type = "text/markdown" }
@@ -88,6 +88,8 @@ lumerical = "gds_fdtd.solvers.lumerical:LumericalSolver"
 Homepage    = "https://github.com/SiEPIC/gds_fdtd"
 Repository  = "https://github.com/SiEPIC/gds_fdtd"
 "Bug Tracker" = "https://github.com/SiEPIC/gds_fdtd/issues"
+Documentation = "https://siepic.github.io/gds_fdtd/"
+Changelog     = "https://github.com/SiEPIC/gds_fdtd/blob/main/CHANGELOG.md"
 
 # ─────────────────────────── tooling ────────────────────────────
 [tool.hatch.version]

--- a/src/gds_fdtd/caching.py
+++ b/src/gds_fdtd/caching.py
@@ -1,7 +1,7 @@
 """
 gds_fdtd simulation toolbox.
 
-Simulation-result caching (WP5.5 item 2). A job is identified by a sha256
+Simulation-result caching. A job is identified by a sha256
 over a canonical JSON fingerprint of everything that determines its result:
 component geometry (structures, ports, bounds), technology, SimulationSpec,
 solver name and engine version. ``cached_run`` short-circuits repeat runs to

--- a/src/gds_fdtd/cli.py
+++ b/src/gds_fdtd/cli.py
@@ -1,7 +1,7 @@
 """
 gds_fdtd simulation toolbox.
 
-Command-line interface (WP7.3). Every simulation is a JSON JobSpec; every
+Command-line interface. Every simulation is a JSON JobSpec; every
 subcommand consumes one (except ``convert``/``solvers``).
 
     gds-fdtd solvers                        # what engines are available here

--- a/src/gds_fdtd/convergence.py
+++ b/src/gds_fdtd/convergence.py
@@ -1,7 +1,7 @@
 """
 gds_fdtd simulation toolbox.
 
-Convergence sweeps (WP5.5 item 1): rerun one job while stepping a single
+Convergence sweeps: rerun one job while stepping a single
 SimulationSpec field (mesh, run_time_factor, buffer, ...) and measure how
 much the S-matrix still moves between successive values. Generalizes the
 hand-rolled mesh sweeps of the legacy examples.

--- a/src/gds_fdtd/core.py
+++ b/src/gds_fdtd/core.py
@@ -1,11 +1,11 @@
 """
 gds_fdtd simulation toolbox.
 
-Legacy core module. The geometry classes moved to gds_fdtd.geometry in WP2.1
+Legacy core module. The geometry classes moved to gds_fdtd.geometry in 0.5
 (port -> Port, structure -> Structure, region -> Region, component -> Component,
 layout -> LayoutSource); importing the old names from here still works but
 emits a DeprecationWarning. The technology class and the legacy s-parameter
-classes still live here until WP2.2 / WP2.4.
+classes still live here until their v1.0 removal.
 @author: Mustafa Hammood, 2025
 """
 
@@ -35,7 +35,7 @@ def __getattr__(name: str):
         new_name = _DEPRECATED_GEOMETRY_NAMES[name]
         warnings.warn(
             f"gds_fdtd.core.{name} is deprecated; use gds_fdtd.geometry.{new_name} "
-            "instead (renamed in WP2.1, removal at v1.0).",
+            "instead (renamed in 0.5, removal at v1.0).",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -61,7 +61,7 @@ def parse_yaml_tech(file_path: str) -> dict:
 
     Note:
         Routes through the validated pydantic model (gds_fdtd.technology.Technology,
-        WP2.2); the returned dict shape is identical to the legacy parser's.
+        the returned dict shape is identical to the legacy parser's.
     """
     from .technology import Technology
 

--- a/src/gds_fdtd/errors.py
+++ b/src/gds_fdtd/errors.py
@@ -1,7 +1,7 @@
 """
 gds_fdtd simulation toolbox.
 
-Exception hierarchy (WP7.6). Every gds_fdtd-raised error derives from
+Exception hierarchy. Every gds_fdtd-raised error derives from
 ``GdsFdtdError`` so applications can catch the whole package with one
 except-clause — while each subclass ALSO derives from the builtin type the
 code historically raised (ValueError, RuntimeError, ...), so no existing

--- a/src/gds_fdtd/execution/__init__.py
+++ b/src/gds_fdtd/execution/__init__.py
@@ -1,4 +1,4 @@
-"""Serializable jobs + execution backends (WP7.3)."""
+"""Serializable jobs + execution backends."""
 
 from .backends import ExecutionBackend, JobHandle, LocalBackend, SubprocessBackend
 from .jobspec import Budget, JobResult, JobSpec, run_job

--- a/src/gds_fdtd/execution/backends.py
+++ b/src/gds_fdtd/execution/backends.py
@@ -1,12 +1,12 @@
 """
 gds_fdtd simulation toolbox.
 
-Execution backends (WP7.3): where a JobSpec runs. ``LocalBackend`` executes
+Execution backends: where a JobSpec runs. ``LocalBackend`` executes
 in-process; ``SubprocessBackend`` spawns ``gds-fdtd run job.json --out dir``
 — proving the serialization boundary and giving crash isolation and
 parallelism (a sweep can submit N jobs and collect as they finish).
 
-Handles are in-memory only (no job database) — a deliberate WP7.3 non-goal.
+Handles are in-memory only (no job database) — deliberately out of scope.
 """
 
 from __future__ import annotations

--- a/src/gds_fdtd/execution/jobspec.py
+++ b/src/gds_fdtd/execution/jobspec.py
@@ -1,7 +1,7 @@
 """
 gds_fdtd simulation toolbox.
 
-Serializable simulation jobs (WP7.3). A JobSpec is everything needed to run
+Serializable simulation jobs. A JobSpec is everything needed to run
 one simulation, as JSON: layout SOURCE references (GDS path + top cell +
 technology YAML), the SimulationSpec, and the solver registry name.
 

--- a/src/gds_fdtd/extraction.py
+++ b/src/gds_fdtd/extraction.py
@@ -1,7 +1,7 @@
 """
 gds_fdtd simulation toolbox.
 
-Mode-overlap extraction (WP5.2c) — the last Tier-B enabler. Kernel engines
+Mode-overlap extraction — the last Tier-B enabler. Kernel engines
 (fdtdz, fdtdx) record raw DFT fields at port planes; this module turns them
 into the complex modal amplitudes that become SMatrix entries. Everything is
 solver-independent numpy: fields in, complex out.

--- a/src/gds_fdtd/geometry.py
+++ b/src/gds_fdtd/geometry.py
@@ -1,9 +1,7 @@
 """
 gds_fdtd simulation toolbox.
 
-Geometry primitives: Port, Structure, Region, Component (WP2.1 — renamed from
-the lowercase classes previously in core.py; gds_fdtd.core re-exports the old
-names with a DeprecationWarning).
+Geometry primitives: Port, Structure, Region, Component.
 @author: Mustafa Hammood, 2025
 """
 
@@ -131,9 +129,8 @@ class Port:
         self.center = center
         self.width = width
         self.direction = direction
-        # initialize height, material, and layer as None
-        # will be assigned upon component __init__
-        # TODO: feels like a better way to do this..
+        # height/material/layer are resolved by Component.__init__ once the
+        # port is matched to a device layer
         self.height: float | None = None
         self.material: object = None
         self.layer: list[int] | None = None
@@ -384,7 +381,7 @@ def initialize_ports_z(ports: list["Port"], structures: list["Structure"]) -> No
     Initialize each port's z-center, height, material, and layer from the DEVICE
     structure containing it (last match wins, as before).
 
-    WP2.3: structures are a flat list discriminated by Structure.role; the old
+    Structures are a flat list discriminated by Structure.role; the old
     list-nesting convention (type(s) == list) is gone. Substrate/superstrate no
     longer silently claim ports that sit outside every device structure — those
     now warn and keep height=None.
@@ -426,7 +423,7 @@ class Component:
         self.name = name
         flat: list[Structure] = []
         for entry in structures:
-            if isinstance(entry, list):  # legacy nested convention (pre-WP2.3)
+            if isinstance(entry, list):  # legacy nested convention (pre-0.5)
                 import warnings
 
                 warnings.warn(

--- a/src/gds_fdtd/grid.py
+++ b/src/gds_fdtd/grid.py
@@ -1,7 +1,7 @@
 """
 gds_fdtd simulation toolbox.
 
-Permittivity rasterizer (WP5.2a) — the first Tier-B enabler. Kernel-level
+Permittivity rasterizer — the first Tier-B enabler. Kernel-level
 engines (fdtdz, fdtdx) take a raw permittivity grid instead of a scene
 graph; ``rasterize`` turns a ``Component`` into that grid offline:
 

--- a/src/gds_fdtd/layout/__init__.py
+++ b/src/gds_fdtd/layout/__init__.py
@@ -1,2 +1,2 @@
-"""Layout ingestion adapters (WP4.2+): KLayout/SiEPIC lives in
+"""Layout ingestion adapters: KLayout/SiEPIC lives in
 gds_fdtd.lyprocessor (legacy home); gdsfactory here."""

--- a/src/gds_fdtd/layout/gdsfactory.py
+++ b/src/gds_fdtd/layout/gdsfactory.py
@@ -1,7 +1,7 @@
 """
 gds_fdtd simulation toolbox.
 
-gdsfactory (>= 9) ingestion (WP4.2). Rewritten from scratch for the gf 9 API
+gdsfactory (>= 9) ingestion. Rewritten from scratch for the gf 9 API
 (verified against gdsfactory 9.45, 2026-07-07):
 
 - ``Component.get_polygons_points(by="tuple")`` -> {(layer, datatype): [Nx2 um]}

--- a/src/gds_fdtd/materials/__init__.py
+++ b/src/gds_fdtd/materials/__init__.py
@@ -1,4 +1,4 @@
-"""Material sources for gds_fdtd (WP2.2)."""
+"""Material sources for gds_fdtd."""
 
 from .rii import RiiMaterial, load_rii_material
 

--- a/src/gds_fdtd/materials/rii.py
+++ b/src/gds_fdtd/materials/rii.py
@@ -1,5 +1,5 @@
 """
-refractiveindex.info database support (WP2.2, owner-requested).
+refractiveindex.info database support.
 
 Reads material pages from a LOCAL copy of the refractiveindex.info database
 (https://github.com/polyanskiy/refractiveindex.info-database) — the DB is

--- a/src/gds_fdtd/modes.py
+++ b/src/gds_fdtd/modes.py
@@ -1,7 +1,7 @@
 """
 gds_fdtd simulation toolbox.
 
-Waveguide mode solving (WP5.2b) — the second Tier-B enabler. Kernel-level
+Waveguide mode solving — the second Tier-B enabler. Kernel-level
 engines need mode profiles at port cross-sections to synthesize sources and
 decompose recorded fields; ``ModeSolver`` is the backend-agnostic protocol
 (raw permittivity cross-section in, ``Mode`` list out) and

--- a/src/gds_fdtd/plotting.py
+++ b/src/gds_fdtd/plotting.py
@@ -1,7 +1,7 @@
 """
 gds_fdtd simulation toolbox.
 
-Plotting helpers for the canonical SMatrix (WP2.4d). matplotlib is imported
+Plotting helpers for the canonical SMatrix. matplotlib is imported
 lazily so headless / minimal installs never pay for it.
 """
 

--- a/src/gds_fdtd/settings.py
+++ b/src/gds_fdtd/settings.py
@@ -1,7 +1,7 @@
 """
 gds_fdtd simulation toolbox.
 
-Package configuration (WP7.6): one pydantic-settings model, environment
+Package configuration: one pydantic-settings model, environment
 prefix ``GDS_FDTD_``. Nothing here reads config files or the network — env
 vars only, so behavior on a laptop, in CI, and inside a container is the
 same mechanism.

--- a/src/gds_fdtd/simprocessor.py
+++ b/src/gds_fdtd/simprocessor.py
@@ -5,6 +5,7 @@ Simulation processing module.
 @author: Mustafa Hammood, 2025
 """
 
+import logging
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -19,6 +20,8 @@ from .lyprocessor import (
     load_structure,
     load_structure_from_bounds,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def get_material(device: dict):
@@ -112,8 +115,8 @@ def _load_tidy3d_material(material_spec: dict):
                 # Try to load from Tidy3D material database
                 return td.material_library[material_name][variant]
             except KeyError:
-                print(f"Warning: Material {material_name}[{variant}] not found in Tidy3D library")
-                print(
+                logger.warning(f"Material {material_name}[{variant}] not found in Tidy3D library")
+                logger.warning(
                     f"Available variants for {material_name}: {list(td.material_library[material_name].keys()) if material_name in td.material_library else 'Material not found'}"
                 )
                 # Fallback to silicon with warning
@@ -126,12 +129,12 @@ def _load_tidy3d_material(material_spec: dict):
                 first_variant = next(iter(material_dict.keys()))
                 return material_dict[first_variant]
             except (KeyError, StopIteration):
-                print(f"Warning: Material {model_spec} not found in Tidy3D library")
+                logger.warning(f"Material {model_spec} not found in Tidy3D library")
                 # Fallback to silicon
                 return td.material_library["cSi"]["Li1993_293K"]
 
     # Fallback: return silicon if nothing else works
-    print("Warning: Could not parse material specification, using default silicon")
+    logger.warning("Could not parse material specification, using default silicon")
     return td.material_library["cSi"]["Li1993_293K"]
 
 
@@ -156,7 +159,7 @@ def load_component_from_tech(cell, tech, z_span=4, z_center=None):
             )
         )
     # Removing empty lists due to no structures existing in an input layer,
-    # then flatten: Component.structures is a flat list with roles (WP2.3)
+    # then flatten: Component.structures is a flat list with roles
     device_wg = [s for dev in device_wg if dev for s in dev]
 
     # get z_center based on structures center (minimize symmetry failures);
@@ -207,7 +210,7 @@ def load_component_from_tech(cell, tech, z_span=4, z_center=None):
 def from_gdsfactory(c, tech: dict, z_span: float = 4.0) -> "Component":
     """Convert a gdsfactory Component to a gds_fdtd Component.
 
-    WP4.2: this is now a thin delegate to gds_fdtd.layout.gdsfactory, which is
+    This is a thin delegate to gds_fdtd.layout.gdsfactory, which is
     written for the gdsfactory >= 9 API (the previous implementation here
     targeted the pre-gf-8 API and carried bugs B2/B3/B4: hardcoded polygon
     index, ports named after the component, wrong units).

--- a/src/gds_fdtd/smatrix.py
+++ b/src/gds_fdtd/smatrix.py
@@ -1,7 +1,7 @@
 """
 gds_fdtd simulation toolbox.
 
-The canonical S-matrix container (WP2.4a). One representation for every solver:
+The canonical S-matrix container. One representation for every solver:
 
 - ``f``: frequency grid in Hz, shape (F,), ascending.
 - ``s``: complex ndarray, shape (F, P, P, M, M) indexed as
@@ -12,8 +12,8 @@ The canonical S-matrix container (WP2.4a). One representation for every solver:
 
 I/O: ``.npz`` always (numpy built-in); ``.h5`` when ``h5py`` is installed.
 Checks: reciprocity, passivity, per-excitation power balance.
-Plotting lives in gds_fdtd.plotting (WP2.4d); Lumerical ``.dat`` and
-Touchstone interop arrive in WP2.4b/c.
+Plotting lives in gds_fdtd.plotting; Lumerical ``.dat`` and
+Touchstone interop live in to_dat/to_touchstone below.
 """
 
 from __future__ import annotations
@@ -174,7 +174,7 @@ class SMatrix:
     # ---------------- I/O ----------------
 
     def to_dat(self, path: str) -> str:
-        """Write to Lumerical INTERCONNECT .dat (via the WP1.6 entry-driven writer).
+        """Write to Lumerical INTERCONNECT .dat (via the entry-driven sparams writer).
 
         Port names are mapped to numeric ids by their trailing digits (or by
         position when a name has none); NaN (unmeasured) paths are skipped.
@@ -216,7 +216,7 @@ class SMatrix:
         return cast("SMatrix", spar.to_smatrix(name=name))
 
     def to_touchstone(self, path: str) -> str:
-        """Write a Touchstone v1 ``.sNp`` file (WP2.4c).
+        """Write a Touchstone v1 ``.sNp`` file.
 
         Convention (documented in the file header): the (port, mode) pairs are
         flattened into N = P*M Touchstone ports ordered

--- a/src/gds_fdtd/solver.py
+++ b/src/gds_fdtd/solver.py
@@ -164,7 +164,7 @@ class fdtd_solver:
                     f"Invalid port object in port_input: {p!r}. Expected component "
                     "port objects (or None for all ports)."
                 )
-        # WP3.1a: all numeric settings are validated through one SimulationSpec;
+        # all numeric settings are validated through one SimulationSpec;
         # the legacy attribute surface below is kept identical (mutable lists).
         self.spec = SimulationSpec(
             wavelength_start=wavelength_start,
@@ -262,7 +262,7 @@ class fdtd_solver:
             # Fallback to default values if component doesn't have bbox
             self.center = [0.0, 0.0, (self.z_max + self.z_min) / 2]
             self.span = [5.0, 5.0, self.z_max - self.z_min]
-            print(
+            self.logger.info(
                 "Warning: Could not determine component geometry, using default simulation domain"
             )
 
@@ -329,7 +329,7 @@ class fdtd_solver:
     def _validate_simulation_parameters(self) -> None:
         """Re-validate the (possibly mutated) legacy attributes through SimulationSpec.
 
-        WP3.1a: the hand-written checks moved into gds_fdtd.spec.SimulationSpec
+        The hand-written checks moved into gds_fdtd.spec.SimulationSpec
         validators. Rebuilding the spec here keeps setup()-time validation
         meaningful for callers that mutated the legacy list attributes after
         construction, and refreshes self.spec to match.
@@ -402,42 +402,39 @@ class fdtd_solver:
         log_dict(self.logger, summary_data, "Simulation Configuration")
 
         # Console output (formatted for readability)
-        print("\n" + "=" * 60)
-        print("FDTD Simulation Summary")
-        print("=" * 60)
-        print(f"Component: {self.component.name}")
-        print(f"Technology: {getattr(self.tech, 'name', 'Custom')}")
-        print(f"Solver type: {self.__class__.__name__}")
-        print(f"Working directory: {self.working_dir}")
-        print()
-        print("Simulation Parameters:")
-        print(f"  Wavelength range: {self.wavelength_start} - {self.wavelength_end} μm")
-        print(f"  Wavelength points: {self.wavelength_points}")
-        print(
+        self.logger.info("\n" + "=" * 60)
+        self.logger.info("FDTD Simulation Summary")
+        self.logger.info("=" * 60)
+        self.logger.info(f"Component: {self.component.name}")
+        self.logger.info(f"Technology: {getattr(self.tech, 'name', 'Custom')}")
+        self.logger.info(f"Solver type: {self.__class__.__name__}")
+        self.logger.info(f"Working directory: {self.working_dir}")
+        self.logger.info("Simulation Parameters:")
+        self.logger.info(f"  Wavelength range: {self.wavelength_start} - {self.wavelength_end} μm")
+        self.logger.info(f"  Wavelength points: {self.wavelength_points}")
+        self.logger.info(
             f"  Simulation domain: {self.span[0]:.1f} × {self.span[1]:.1f} × {self.span[2]:.1f} μm"
         )
-        print(
+        self.logger.info(
             f"  Domain center: ({self.center[0]:.1f}, {self.center[1]:.1f}, {self.center[2]:.1f}) μm"
         )
-        print(f"  Mesh resolution: {self.mesh} cells/wavelength")
-        print(f"  Run time factor: {self.run_time_factor}")
-        print()
-        print("Port Configuration:")
-        print(f"  Total ports: {len(self.fdtd_ports)}")
-        print(f"  Active ports: {len(self._get_active_ports())}")
-        print(f"  Port dimensions: {self.width_ports} × {self.depth_ports} μm")
-        print(f"  Modes per port: {self.modes}")
-        print()
-        print("Boundary Conditions:")
-        print(f"  Boundaries: {self.boundary}")
-        print(f"  Symmetry: {self.symmetry}")
-        print("=" * 60 + "\n")
+        self.logger.info(f"  Mesh resolution: {self.mesh} cells/wavelength")
+        self.logger.info(f"  Run time factor: {self.run_time_factor}")
+        self.logger.info("Port Configuration:")
+        self.logger.info(f"  Total ports: {len(self.fdtd_ports)}")
+        self.logger.info(f"  Active ports: {len(self._get_active_ports())}")
+        self.logger.info(f"  Port dimensions: {self.width_ports} × {self.depth_ports} μm")
+        self.logger.info(f"  Modes per port: {self.modes}")
+        self.logger.info("Boundary Conditions:")
+        self.logger.info(f"  Boundaries: {self.boundary}")
+        self.logger.info(f"  Symmetry: {self.symmetry}")
+        self.logger.info("=" * 60 + "\n")
 
     @property
     def sparameters(self) -> sparameters:
         """Get the S-parameters results."""
         if self._sparameters is None:
-            print("S-parameters results not available. Please run the simulation first.")
+            self.logger.info("S-parameters results not available. Please run the simulation first.")
         return self._sparameters
 
     def setup(self) -> None:

--- a/src/gds_fdtd/solver_lumerical.py
+++ b/src/gds_fdtd/solver_lumerical.py
@@ -6,7 +6,6 @@ Lumerical tools interface module.
 """
 
 import os
-import re
 
 from lumapi import FDTD
 
@@ -64,7 +63,7 @@ class fdtd_solver_lumerical(fdtd_solver):
         project_filepath = os.path.join(self.working_dir, f"{self.component.name}.fsp")
         self.fdtd.save(project_filepath)
         self.logger.info(f"FDTD project saved: {project_filepath}")
-        print(f"FDTD project saved: {project_filepath}")
+        self.logger.info(f"FDTD project saved: {project_filepath}")
 
         # Get the resources used by the simulation
         self.get_resources()
@@ -85,9 +84,9 @@ class fdtd_solver_lumerical(fdtd_solver):
         memory = reqs.get("Memory_Recommended")  # Bytes (2024 API)
         nodes = reqs.get("Total_FDTD_Yee_Nodes")  # MNodes (2024 API)
         if memory is not None:
-            print(f"Memory: {memory / 1e9} GB")
+            self.logger.info(f"Memory: {memory / 1e9} GB")
         if nodes is not None:
-            print(f"Nodes: {nodes} MNodes")
+            self.logger.info(f"Nodes: {nodes} MNodes")
         if memory is None and nodes is None:
             self.logger.info(
                 "runsystemcheck reported no resource estimates (Lumerical 2025+ "
@@ -176,7 +175,7 @@ class fdtd_solver_lumerical(fdtd_solver):
             try:
                 self.fdtd.removesweepparameter("sparams", 1)
             except Exception:
-                print("Done removing sweep parameters")
+                self.logger.info("Done removing sweep parameters")
                 break
 
         # Add all port-mode combinations to the sweep
@@ -186,18 +185,18 @@ class fdtd_solver_lumerical(fdtd_solver):
         # Print summary of S-parameter sweep configuration
         active_combinations = [idx for idx in indices if idx["Active"] == 1]
         total_combinations = len(indices)
-        print("S-parameter sweep configured:")
-        print(f"  Total port-mode combinations: {total_combinations}")
-        print(f"  Active combinations: {len(active_combinations)}")
-        print(f"  Active ports: {active_port_names}")
-        print(f"  Modes: {self.modes}")
+        self.logger.info("S-parameter sweep configured:")
+        self.logger.info(f"  Total port-mode combinations: {total_combinations}")
+        self.logger.info(f"  Active combinations: {len(active_combinations)}")
+        self.logger.info(f"  Active ports: {active_port_names}")
+        self.logger.info(f"  Modes: {self.modes}")
 
         if len(active_combinations) > 0:
-            print("  Active combinations:")
+            self.logger.info("  Active combinations:")
             for combo in active_combinations:
-                print(f"    {combo['Port']} - {combo['Mode']}")
+                self.logger.info(f"    {combo['Port']} - {combo['Mode']}")
         else:
-            print("  Warning: No active port-mode combinations found!")
+            self.logger.info("  Warning: No active port-mode combinations found!")
 
     def _setup_layer_builder(self) -> None:
         """
@@ -319,19 +318,19 @@ class fdtd_solver_lumerical(fdtd_solver):
                     )
 
                 layers_added += 1
-                print(
+                self.logger.info(
                     f"Added layer {layer_name} for GDS layer {layer_spec} at z={device_layer['z_base']}μm, thickness={device_layer['z_span']}μm"
                 )
             else:
-                print(
+                self.logger.info(
                     f"Skipping device layer {idx} (GDS layer {gds_layer[0]}:{gds_layer[1]}) - not found in GDS file"
                 )
 
-        print(
+        self.logger.info(
             f"Layer builder setup complete with {layers_added} device layers (out of {len(tech_dict['device'])} defined in technology)"
         )
         if gds_layers_result is not None:
-            print(f"GDS file contains layers: {gds_layers_result}")
+            self.logger.info(f"GDS file contains layers: {gds_layers_result}")
 
     def _setup_fdtd(self) -> None:
         """Setup the FDTD simulation."""
@@ -343,13 +342,16 @@ class fdtd_solver_lumerical(fdtd_solver):
         self.fdtd.setnamed("FDTD", "y span", (self.span[1]) * 1e-6)
         self.fdtd.setnamed("FDTD", "z span", self.span[2] * 1e-6)
 
-        # configure GPU acceleration
-        # TODO: IMPORTANT: This is valid for Lumerical 2024.
-        # For Lumerical 2025, Lumerical has changed the syntax for setting GPU.
-        # If you do, please update the code to make it work for 2025 as well as 2024
-        # I Don't have a 2025 license, so I can't test it.
+        # GPU: Lumerical 2024 uses 'express mode' here; 2025 switched to
+        # setresource, handled by _set_device_type() at run() (finding F7).
+        # Tolerate either vintage.
         if self.gpu:
-            self.fdtd.setnamed("FDTD", "express mode", True)
+            try:
+                self.fdtd.setnamed("FDTD", "express mode", True)
+            except Exception:
+                self.logger.debug(
+                    "'express mode' unavailable (Lumerical 2025+); using setresource at run()"
+                )
         else:
             self.fdtd.setnamed("FDTD", "express mode", False)
 
@@ -486,7 +488,7 @@ class fdtd_solver_lumerical(fdtd_solver):
                 min_diff = diff
                 mesh_option = option
 
-        print(
+        self.logger.info(
             f"User requested {self.mesh} mesh cells per wavelength, using mesh option {mesh_option} ({possible_meshes[mesh_option]} cells per wavelength)"
         )
 
@@ -546,48 +548,3 @@ class fdtd_solver_lumerical(fdtd_solver):
                 return "FDTD solver not initialized."
         except Exception as e:
             return f"Error retrieving log: {str(e)}"
-
-    def _extract_log_metrics(self, log_text: str) -> dict:
-        """
-        Extract Lumerical-specific metrics from log text.
-
-        Args:
-            log_text: Raw Lumerical log text
-
-        Returns:
-            dict: Extracted metrics specific to Lumerical
-        """
-        log_metrics = super()._extract_log_metrics(log_text)
-
-        try:
-            # TODO: Implement Lumerical-specific log parsing
-            # This will depend on the actual format of Lumerical logs
-            # For now, we'll add basic parsing patterns
-
-            # Memory usage
-            memory_match = re.search(r"Memory.*?(\d+\.?\d*)\s*GB", log_text, re.IGNORECASE)
-            if memory_match:
-                log_metrics["memory_gb"] = float(memory_match.group(1))
-
-            # Simulation time
-            sim_time_match = re.search(
-                r"simulation time.*?(\d+\.?\d*)\s*s", log_text, re.IGNORECASE
-            )
-            if sim_time_match:
-                log_metrics["simulation_time"] = float(sim_time_match.group(1))
-
-            # Time steps
-            time_steps_match = re.search(r"time steps.*?(\d+)", log_text, re.IGNORECASE)
-            if time_steps_match:
-                log_metrics["time_steps"] = int(time_steps_match.group(1))
-
-            # Note: This is a placeholder implementation
-            # Actual Lumerical log format will need to be analyzed for proper parsing
-            log_metrics["note"] = (
-                "Lumerical log parsing is placeholder - needs actual log format analysis"
-            )
-
-        except Exception as e:
-            self.logger.warning(f"Error extracting Lumerical log metrics: {e}")
-
-        return log_metrics

--- a/src/gds_fdtd/solver_tidy3d.py
+++ b/src/gds_fdtd/solver_tidy3d.py
@@ -56,7 +56,7 @@ class fdtd_solver_tidy3d(fdtd_solver):
 
         # Create the modeler for S-matrix calculation.
         # tidy3d >=2.9 renamed ComponentModeler -> ModalComponentModeler and
-        # moved web options (verbose/path_dir) to tidy3d.web.run (WP4.1).
+        # moved web options (verbose/path_dir) to tidy3d.web.run.
         self.component_modeler = ModalComponentModeler(
             simulation=self.base_simulation,
             ports=self.smatrix_ports,
@@ -70,12 +70,14 @@ class fdtd_solver_tidy3d(fdtd_solver):
         setup_info = f"Tidy3D solver setup complete with ComponentModeler: {len(self.smatrix_ports)} ports × {len(self.modes)} modes = {total_mode_combinations} mode combinations"
         self.logger.info(setup_info)
 
-        print("Tidy3D solver setup complete with ComponentModeler:")
-        print(
+        self.logger.info("Tidy3D solver setup complete with ComponentModeler:")
+        self.logger.info(
             f"  • {len(self.smatrix_ports)} ports × {len(self.modes)} modes = {total_mode_combinations} mode combinations"
         )
-        print("  • Multi-modal S-matrix calculation ready")
-        print(f"  • ComponentModeler will auto-generate task names for {self.component.name}")
+        self.logger.info("  • Multi-modal S-matrix calculation ready")
+        self.logger.info(
+            f"  • ComponentModeler will auto-generate task names for {self.component.name}"
+        )
 
     def _create_base_simulation(self):
         """Create base simulation without sources/monitors for ComponentModeler."""
@@ -193,7 +195,7 @@ class fdtd_solver_tidy3d(fdtd_solver):
 
     @staticmethod
     def _is_background(structure) -> bool:
-        """Background = substrate/superstrate, by ROLE (WP2.3), with a
+        """Background = substrate/superstrate, by ROLE, with a
         name-sniffing fallback only for td.Structure objects in tests."""
         role = getattr(structure, "role", None)
         if role is not None:
@@ -283,16 +285,16 @@ class fdtd_solver_tidy3d(fdtd_solver):
     def get_resources(self) -> None:
         """Get the resources used by the simulation."""
         if not hasattr(self, "component_modeler"):
-            print("No ComponentModeler available.")
+            self.logger.info("No ComponentModeler available.")
             return
 
         total_simulations = len(self.smatrix_ports) * len(self.modes)
-        print("ComponentModeler Multi-Modal Configuration:")
-        print(f"  • {len(self.smatrix_ports)} ports")
-        print(f"  • {len(self.modes)} modes per port: {self.modes}")
-        print(f"  • Total simulations required: {total_simulations}")
-        print(f"  • Component: {self.component.name}")
-        print("Resource estimation handled by Tidy3D cloud platform")
+        self.logger.info("ComponentModeler Multi-Modal Configuration:")
+        self.logger.info(f"  • {len(self.smatrix_ports)} ports")
+        self.logger.info(f"  • {len(self.modes)} modes per port: {self.modes}")
+        self.logger.info(f"  • Total simulations required: {total_simulations}")
+        self.logger.info(f"  • Component: {self.component.name}")
+        self.logger.info("Resource estimation handled by Tidy3D cloud platform")
 
     def run(self) -> None:
         """Run the simulation using ComponentModeler."""
@@ -302,7 +304,7 @@ class fdtd_solver_tidy3d(fdtd_solver):
             raise RuntimeError(error_msg)
 
         log_simulation_start(self.logger, "Tidy3D ComponentModeler", self.component.name)
-        print("Running S-matrix calculation with ComponentModeler...")
+        self.logger.info("Running S-matrix calculation with ComponentModeler...")
 
         # Run the S-matrix calculation through the tidy3d web API (2.11 workflow).
         # tidy3d.web is a LAZILY imported submodule: `import tidy3d as td` does
@@ -328,7 +330,7 @@ class fdtd_solver_tidy3d(fdtd_solver):
         self._convert_smatrix_to_sparameters(smatrix_result)
 
         log_simulation_complete(self.logger, "Tidy3D ComponentModeler")
-        print("S-matrix calculation completed successfully!")
+        self.logger.info("S-matrix calculation completed successfully!")
 
     def _convert_smatrix_to_sparameters(self, smatrix_result):
         """Convert Tidy3D S-matrix results to sparameters format with multi-modal support."""
@@ -339,9 +341,9 @@ class fdtd_solver_tidy3d(fdtd_solver):
         freqs = smatrix_result.coords["f"].values
         wavelengths = td.C_0 / freqs
 
-        print(f"Converting S-matrix results: {len(freqs)} frequency points")
-        print(f"Available ports: {list(smatrix_result.coords['port_in'].values)}")
-        print(f"Available modes: {list(smatrix_result.coords['mode_index_in'].values)}")
+        self.logger.info(f"Converting S-matrix results: {len(freqs)} frequency points")
+        self.logger.info(f"Available ports: {list(smatrix_result.coords['port_in'].values)}")
+        self.logger.info(f"Available modes: {list(smatrix_result.coords['mode_index_in'].values)}")
 
         # Process all S-matrix elements for multi-modal case
         for port_in in smatrix_result.coords["port_in"].values:
@@ -386,14 +388,14 @@ class fdtd_solver_tidy3d(fdtd_solver):
                             s_phase=list(s_phase),
                         )
 
-                        print(
+                        self.logger.info(
                             f"Added S-parameter: Port {in_port_num}(mode {mode_in_1based}) -> Port {out_port_num}(mode {mode_out_1based})"
                         )
 
         # Store the raw Tidy3D results for field visualization
         self.smatrix_result = smatrix_result
 
-        print(
+        self.logger.info(
             f"Multi-modal S-matrix conversion complete: {len(self._sparameters.data)} S-parameter entries"
         )
 
@@ -410,7 +412,7 @@ class fdtd_solver_tidy3d(fdtd_solver):
     def get_results(self) -> None:
         """Get the results of the simulation."""
         if not hasattr(self, "_sparameters") or self._sparameters is None:
-            print("No results available. Run simulation first.")
+            self.logger.info("No results available. Run simulation first.")
             return
         # Results are already stored in self._sparameters by _convert_smatrix_to_sparameters
 
@@ -429,17 +431,17 @@ class fdtd_solver_tidy3d(fdtd_solver):
                     logs.append(f"=== {task_name} ===\n{log}")
             return "\n".join(logs) if logs else "No per-task logs exposed by this tidy3d version."
         except Exception as e:
-            print(f"Error retrieving Tidy3D log: {e}")
+            self.logger.info(f"Error retrieving Tidy3D log: {e}")
             return f"Log retrieval error: {str(e)}"
 
     def visualize_field_monitors(self, freq=None, axis: str = "z", savefig: str | None = None):
-        """Plot the run's field profile (redeems the WP1.9 deferral).
+        """Plot the run's field profile.
 
         Uses the per-task SimulationData from the 2.11 modeler results.
         """
         data = getattr(self, "_modeler_data", None)
         if data is None:
-            print("No field data: run() has not completed.")
+            self.logger.info("No field data: run() has not completed.")
             return None
         from gds_fdtd.solvers.tidy3d import plot_tidy3d_fields
 

--- a/src/gds_fdtd/solvers/__init__.py
+++ b/src/gds_fdtd/solvers/__init__.py
@@ -1,6 +1,6 @@
 """Solver adapters implementing the Phase-3 contract (gds_fdtd.solvers.base).
 
-The tidy3d/lumerical adapters are ported onto this contract in WP3.1c/d; the
+The tidy3d/lumerical/beamz adapters implement this contract; the
 legacy gds_fdtd.solver_tidy3d / solver_lumerical modules keep working until
 then.
 """

--- a/src/gds_fdtd/solvers/base.py
+++ b/src/gds_fdtd/solvers/base.py
@@ -1,7 +1,7 @@
 """
 gds_fdtd simulation toolbox.
 
-The Phase-3 solver contract (WP3.1b). Every engine adapter implements:
+The Phase-3 solver contract. Every engine adapter implements:
 
     validate() -> list[str]        # human-readable problems; [] = ok
     build()    -> SetupArtifacts   # native scene, OFFLINE, serializable
@@ -10,9 +10,9 @@ The Phase-3 solver contract (WP3.1b). Every engine adapter implements:
                                    # money / licenses / GPU time
 
 Constructors MUST be cheap and pure: no disk writes, no network, no license
-checks (rule 10 / the remote-compute invariant in MODERNIZATION_PLAN.md).
+checks — the remote-compute invariant: a JobSpec must be buildable anywhere.
 The legacy ``fdtd_solver`` hierarchy remains in gds_fdtd.solver until the
-adapters are ported (WP3.1c/d); nothing imports this module yet besides the
+adapters are ported; nothing imports this module yet besides the
 conformance tests and FakeSolver.
 """
 
@@ -250,7 +250,7 @@ def register_solver(cls: type[Solver]) -> type[Solver]:
 def available_solvers() -> dict[str, str]:
     """Registered solver names -> availability ('ok' or the import problem).
 
-    Entry-point discovery (external plugins) is wired in WP3.1e; for now this
+    Entry-point discovery covers external plugins; this also
     reports the in-package registrations.
     """
     _scan_entry_points()

--- a/src/gds_fdtd/solvers/beamz.py
+++ b/src/gds_fdtd/solvers/beamz.py
@@ -1,8 +1,7 @@
 """
 gds_fdtd simulation toolbox.
 
-BeamzSolver: the beamz (>= 0.4) adapter on the Phase-3 Solver contract
-(WP5.3, owner-requested). beamz is an open-source JAX FDTD engine
+BeamzSolver: the beamz (>= 0.4) adapter on the Phase-3 Solver contract. beamz is an open-source JAX FDTD engine
 (Apache-2.0, pip-installable, CPU or GPU) — the first zero-cost engine in the
 registry.
 
@@ -180,7 +179,7 @@ class BeamzSolver(Solver):
             problems.append(
                 "BeamzSolver v1 needs a gdsfactory-sourced component: convert with "
                 "layout.gdsfactory.from_gdsfactory (it is picked up automatically); "
-                "KLayout-sourced components need the WP5.2 kernel pipeline"
+                "KLayout-sourced components are not supported by this adapter yet"
             )
         if self.technology is None:
             problems.append("BeamzSolver requires a technology")

--- a/src/gds_fdtd/solvers/lumerical.py
+++ b/src/gds_fdtd/solvers/lumerical.py
@@ -2,7 +2,7 @@
 gds_fdtd simulation toolbox.
 
 LumericalSolver: the Ansys Lumerical FDTD adapter on the Phase-3 Solver
-contract (WP3.1d). ``build()`` generates the COMPLETE setup script (.lsf) as
+contract. ``build()`` generates the COMPLETE setup script (.lsf) as
 pure text plus the exported GDS — offline, deterministic, no license, no
 lumapi import — mirroring the validated legacy ``fdtd_solver_lumerical``
 semantics (incl. the F6/F7 Lumerical-2025 fixes). ``run()`` is the only

--- a/src/gds_fdtd/solvers/tidy3d.py
+++ b/src/gds_fdtd/solvers/tidy3d.py
@@ -1,14 +1,13 @@
 """
 gds_fdtd simulation toolbox.
 
-Tidy3DSolver: the tidy3d (>=2.11) adapter on the Phase-3 Solver contract
-(WP3.1c). Composition strategy: the scene construction reuses the validated
+Tidy3DSolver: the tidy3d (>=2.11) adapter on the Phase-3 Solver contract. Composition strategy: the scene construction reuses the validated
 legacy ``fdtd_solver_tidy3d`` machinery, but ONLY inside ``build()`` — the
 constructor stays pure per the contract, and ``run()`` is the only method
 that talks to the tidy3d cloud.
 
 The legacy class remains fully supported; it and this adapter share one
-implementation, so the WP1.5 offline tests and the live cloud validation
+implementation, so the offline tests and the live cloud validation
 cover both.
 """
 
@@ -81,7 +80,7 @@ class Tidy3DSolver(Solver):
                 if "tidy3d_db" not in mat:
                     problems.append(
                         f"device layer {i} has no 'tidy3d_db' material entry "
-                        "(rii/other sources are wired to tidy3d in WP5.x)"
+                        "(rii/other neutral sources are not wired to tidy3d yet)"
                     )
         return problems
 
@@ -215,7 +214,7 @@ def plot_tidy3d_fields(modeler_data, axis: str = "z", savefig: str | None = None
     """Plot |E| of the '{axis}_field' monitor from a ModalComponentModelerData.
 
     Shared by Tidy3DSolver.plot_fields and the legacy solver's
-    visualize_field_monitors (the WP1.9/WP4.1 promise, redeemed here).
+    visualize_field_monitors.
     """
     import matplotlib.pyplot as plt
 

--- a/src/gds_fdtd/sparams.py
+++ b/src/gds_fdtd/sparams.py
@@ -272,7 +272,7 @@ class sparameters:
             logging.error("No valid data to visualize")
 
     def to_smatrix(self, name: str | None = None):
-        """Convert to the canonical gds_fdtd.smatrix.SMatrix (WP2.4b).
+        """Convert to the canonical gds_fdtd.smatrix.SMatrix.
 
         Magnitude/phase entries become complex amplitudes; port names are
         carried through as-is; unmeasured paths stay NaN in the result.

--- a/src/gds_fdtd/spec.py
+++ b/src/gds_fdtd/spec.py
@@ -1,7 +1,7 @@
 """
 gds_fdtd simulation toolbox.
 
-SimulationSpec (WP3.1a): one validated pydantic model for every numeric
+SimulationSpec: one validated pydantic model for every numeric
 simulation setting that was previously ~15 loose solver kwargs. Defaults are
 IDENTICAL to the historical fdtd_solver defaults. All lengths are um, angles
 degrees, frequencies Hz (package-wide convention).

--- a/src/gds_fdtd/technology.py
+++ b/src/gds_fdtd/technology.py
@@ -1,7 +1,7 @@
 """
 gds_fdtd simulation toolbox.
 
-Technology definition as validated pydantic models (WP2.2).
+Technology definition as validated pydantic models.
 
 The YAML format is UNCHANGED from the legacy parser (schema v1; the existing
 key names — including per-solver material hints ``tidy3d_db``/``lum_db`` — are

--- a/src/gds_fdtd/validation.py
+++ b/src/gds_fdtd/validation.py
@@ -1,7 +1,7 @@
 """
 gds_fdtd simulation toolbox.
 
-Cross-solver validation (WP5.5 item 3) — the payoff of solver agnosticism:
+Cross-solver validation — the payoff of solver agnosticism:
 run the SAME component/technology/spec through several engines and quantify
 how well their S-matrices agree.
 

--- a/tests/test_simprocessor_materials.py
+++ b/tests/test_simprocessor_materials.py
@@ -52,20 +52,29 @@ def test_model_pair_lookup(fake_tidy3d):
     assert _load({"model": ["Si3N4", "Luke2015PMLStable"]}, fake_tidy3d) == "SIN_MEDIUM"
 
 
-def test_model_pair_unknown_falls_back_to_silicon(fake_tidy3d, capsys):
-    assert _load({"model": ["Unobtainium", "X"]}, fake_tidy3d) == "CSI_MEDIUM"
-    assert "not found" in capsys.readouterr().out
+def test_model_pair_unknown_falls_back_to_silicon(fake_tidy3d, caplog):
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="gds_fdtd.simprocessor"):
+        assert _load({"model": ["Unobtainium", "X"]}, fake_tidy3d) == "CSI_MEDIUM"
+    assert "not found" in caplog.text
 
 
 def test_model_string_takes_first_variant(fake_tidy3d):
     assert _load({"model": "Si3N4"}, fake_tidy3d) == "SIN_MEDIUM"
 
 
-def test_model_string_unknown_falls_back(fake_tidy3d, capsys):
-    assert _load({"model": "Nothingite"}, fake_tidy3d) == "CSI_MEDIUM"
-    assert "not found" in capsys.readouterr().out
+def test_model_string_unknown_falls_back(fake_tidy3d, caplog):
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="gds_fdtd.simprocessor"):
+        assert _load({"model": "Nothingite"}, fake_tidy3d) == "CSI_MEDIUM"
+    assert "not found" in caplog.text
 
 
-def test_unparseable_spec_falls_back(fake_tidy3d, capsys):
-    assert _load({"weird": True}, fake_tidy3d) == "CSI_MEDIUM"
-    assert "Could not parse" in capsys.readouterr().out
+def test_unparseable_spec_falls_back(fake_tidy3d, caplog):
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="gds_fdtd.simprocessor"):
+        assert _load({"weird": True}, fake_tidy3d) == "CSI_MEDIUM"
+    assert "Could not parse" in caplog.text


### PR DESCRIPTION
Fresh-eyes audit of the released package, driven by installing the actual wheel into a clean venv. Findings and fixes in the commit message; headline: example 09a broke on a clean install (fixed), 66 library print()s -> logging, internal plan refs scrubbed from all shipped docstrings, two stale docs pages rewritten, one dead-and-broken method removed, README/pyproject metadata corrected.

Full gate green: suite, ruff, codespell, mypy --strict core, sphinx (0 warnings), fresh-venv smoke.