### PR TITLE
Flatten the Tidy3D engine: remove the last fdtd_solver/fdtd_port names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,17 +44,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.dat` fuzz target).
 
 ### Changed
-- The Tidy3D scene-building engine moved to an internal module
-  (`gds_fdtd.solvers._tidy3d_engine`); the supported `Tidy3DSolver` adapter
-  no longer depends on the deprecated `fdtd_solver_tidy3d` class (the
-  dependency now points deprecated → supported, not the reverse).
+- The Tidy3D scene-building engine is now fully internal and honestly named.
+  The generic `fdtd_solver`/`fdtd_port` engine classes (the last pre-0.5 names
+  in the tree) were renamed to `_TidyEngineBase`/`_TidyPort`, and the module
+  `solvers/_engine_base.py` → `solvers/_tidy3d_base.py`. The supported
+  `Tidy3DSolver` adapter is the only entry point; the engine base no longer
+  imports the legacy `core.technology` type (it took the modern `Technology`
+  in practice). No public API changed — all of these names are internal.
 - `mypy --strict` is now enforced on 13 modules (was 5), covering the whole
   modern core; two latent type bugs were fixed in the process.
-
-### Deprecated
-- `fdtd_solver_tidy3d` and `fdtd_solver_lumerical` emit `DeprecationWarning`
-  on instantiation and will be removed in 1.0. Use
-  `gds_fdtd.solvers.get_solver("tidy3d" | "lumerical")(component, tech, spec)`.
 
 ### Security
 - Branch protection enabled on `main`; solo-friendly (PR + green CI +

--- a/src/gds_fdtd/solvers/_tidy3d_base.py
+++ b/src/gds_fdtd/solvers/_tidy3d_base.py
@@ -1,18 +1,21 @@
 """
 gds_fdtd simulation toolbox.
 
-Internal engine base (``fdtd_solver`` + ``fdtd_port``): geometry/port/domain
-setup shared by the Tidy3D scene-building engine. Not a public module.
-
-FDTD solver module.
+Internal base for the Tidy3D scene-building engine: the solver-agnostic
+geometry/port/domain setup (``_TidyEngineBase`` + ``_TidyPort``) that the
+Tidy3D engine builds on. Kept separate from the tidy3d-specific engine so this
+setup logic stays importable and testable WITHOUT tidy3d installed. Not a
+public module.
 @author: Mustafa Hammood, 2025
 """
+
+from __future__ import annotations
 
 import os
 from abc import abstractmethod
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from gds_fdtd.core import technology
 from gds_fdtd.geometry import Component, Port
 from gds_fdtd.logging_config import (
     log_dict,
@@ -22,8 +25,11 @@ from gds_fdtd.logging_config import (
 from gds_fdtd.sparams import sparameters
 from gds_fdtd.spec import SimulationSpec
 
+if TYPE_CHECKING:
+    from gds_fdtd.technology import Technology
 
-class fdtd_port:
+
+class _TidyPort:
     """
     Represents a port in an FDTD simulation.
 
@@ -74,13 +80,13 @@ class fdtd_port:
             raise ValueError("Modes must be a list of integers")
 
 
-class fdtd_solver:
+class _TidyEngineBase:
     """
     FDTD solver for electromagnetic simulations.
 
     Attributes:
         component (component): Component to simulate.
-        tech (technology): Technology to use for the simulation.
+        tech (Technology): Technology to use for the simulation.
         port_input (list of port): Input ports of the component.
         wavelength_start (float): Starting wavelength for simulation.
         wavelength_end (float): Ending wavelength for simulation.
@@ -99,14 +105,14 @@ class fdtd_solver:
         field_monitors (list of str): List of field monitoring directions.
         working_dir (str): Base directory where a component-specific subdirectory will be created for FDTD project files.
         component_working_dir (str): Same as working_dir, the component-specific directory path.
-        fdtd_ports (list of fdtd_port): List of converted FDTD port objects.
+        tidy_ports (list of _TidyPort): List of converted FDTD port objects.
 
     """
 
     def __init__(
         self,
         component: Component,
-        tech: technology,
+        tech: Technology | None,
         port_input: Port | list[Port] | None = None,
         wavelength_start: float = 1.5,
         wavelength_end: float = 1.6,
@@ -130,7 +136,7 @@ class fdtd_solver:
 
         Parameters:
             component (component): Component to simulate.
-            tech (technology): Technology to use for the simulation.
+            tech (Technology): Technology to use for the simulation.
             port_input (list of port): Input ports of the component.
             wavelength_start (float): Simulation start wavelength in micrometers.
             wavelength_end (float): Simulation end wavelength in micrometers.
@@ -229,8 +235,8 @@ class fdtd_solver:
         # Auto-calculate center and span from component geometry
         self._calculate_simulation_domain()
 
-        # Convert component ports to fdtd_port objects for modular solver implementation
-        self.fdtd_ports: list[fdtd_port] = self._convert_component_ports_to_fdtd_ports()
+        # Convert component ports to _TidyPort objects for modular solver implementation
+        self.tidy_ports: list[_TidyPort] = self._build_tidy_ports()
 
         self.field_monitors_objs = []
         self._sparameters = None
@@ -269,9 +275,9 @@ class fdtd_solver:
                 "Warning: Could not determine component geometry, using default simulation domain"
             )
 
-    def _convert_component_ports_to_fdtd_ports(self) -> list[fdtd_port]:
+    def _build_tidy_ports(self) -> list[_TidyPort]:
         """
-        Convert component ports to fdtd_port objects for modular solver implementation.
+        Convert component ports to _TidyPort objects for modular solver implementation.
 
         This method creates a solver-agnostic representation of ports that can be used
         by different FDTD solver implementations (Lumerical, Tidy3D, etc.).
@@ -279,9 +285,9 @@ class fdtd_solver:
         Ports are sorted by their index (extracted from port names) to ensure consistent ordering.
 
         Returns:
-            list[fdtd_port]: List of fdtd_port objects with standardized attributes, sorted by port index.
+            list[_TidyPort]: List of _TidyPort objects with standardized attributes, sorted by port index.
         """
-        fdtd_ports = []
+        ports = []
 
         # Sort ports by their index to ensure consistent ordering
         # This uses the port.idx property which extracts the numeric part from port names
@@ -312,8 +318,8 @@ class fdtd_solver:
                     f"Port direction {p.direction}° not supported. Supported directions: 0°, 90°, 180°, 270°"
                 )
 
-            # Create standardized fdtd_port object
-            fdtd_port_obj = fdtd_port(
+            # Create standardized _TidyPort object
+            tidy_port = _TidyPort(
                 name=p.name,
                 position=[p.center[0], p.center[1], p.center[2]],
                 span=span,
@@ -321,9 +327,9 @@ class fdtd_solver:
                 modes=self.modes,  # Use solver's mode configuration
             )
 
-            fdtd_ports.append(fdtd_port_obj)
+            ports.append(tidy_port)
 
-        return fdtd_ports
+        return ports
 
     def _get_active_ports(self) -> list[str]:
         """Names of the ports to excite (port_input is normalized to a list in __init__)."""
@@ -394,7 +400,7 @@ class fdtd_solver:
             "Domain center": f"({self.center[0]:.1f}, {self.center[1]:.1f}, {self.center[2]:.1f}) μm",
             "Mesh resolution": f"{self.mesh} cells/wavelength",
             "Run time factor": self.run_time_factor,
-            "Total ports": len(self.fdtd_ports),
+            "Total ports": len(self.tidy_ports),
             "Active ports": len(self._get_active_ports()),
             "Port dimensions": f"{self.width_ports} × {self.depth_ports} μm",
             "Modes per port": self.modes,
@@ -424,7 +430,7 @@ class fdtd_solver:
         self.logger.info(f"  Mesh resolution: {self.mesh} cells/wavelength")
         self.logger.info(f"  Run time factor: {self.run_time_factor}")
         self.logger.info("Port Configuration:")
-        self.logger.info(f"  Total ports: {len(self.fdtd_ports)}")
+        self.logger.info(f"  Total ports: {len(self.tidy_ports)}")
         self.logger.info(f"  Active ports: {len(self._get_active_ports())}")
         self.logger.info(f"  Port dimensions: {self.width_ports} × {self.depth_ports} μm")
         self.logger.info(f"  Modes per port: {self.modes}")

--- a/src/gds_fdtd/solvers/_tidy3d_engine.py
+++ b/src/gds_fdtd/solvers/_tidy3d_engine.py
@@ -1,9 +1,9 @@
 """
 gds_fdtd simulation toolbox.
 
-Internal Tidy3D scene-building engine. Shared implementation used by the
-supported ``gds_fdtd.solvers.tidy3d.Tidy3DSolver`` adapter and by the
-deprecated ``gds_fdtd.solver_tidy3d.fdtd_solver_tidy3d`` public alias.
+Internal Tidy3D scene-building engine, the implementation behind the supported
+``gds_fdtd.solvers.tidy3d.Tidy3DSolver`` adapter. The tidy3d-independent
+geometry/port/domain setup lives in the sibling ``_tidy3d_base`` module.
 Not a public module.
 """
 
@@ -14,11 +14,11 @@ import tidy3d as td
 from tidy3d.plugins.smatrix import ModalComponentModeler, Port
 
 from gds_fdtd.logging_config import log_simulation_complete, log_simulation_start
-from gds_fdtd.solvers._engine_base import fdtd_solver
+from gds_fdtd.solvers._tidy3d_base import _TidyEngineBase
 from gds_fdtd.sparams import sparameters
 
 
-class _TidyEngine(fdtd_solver):
+class _TidyEngine(_TidyEngineBase):
     """Tidy3D ComponentModeler scene builder + runner (internal engine)."""
 
     def __init__(self, *args, visualize: bool = True, **kwargs):
@@ -150,23 +150,23 @@ class _TidyEngine(fdtd_solver):
         """Create Tidy3D Port objects for S-matrix calculation with multi-modal support."""
         ports = []
 
-        for fdtd_port in self.fdtd_ports:
-            # Determine port direction and size based on fdtd_port configuration
-            if fdtd_port.span[0] is None:  # x-axis injection
-                direction = "+" if fdtd_port.direction == "forward" else "-"
+        for tp in self.tidy_ports:
+            # Determine port direction and size based on the _TidyPort configuration
+            if tp.span[0] is None:  # x-axis injection
+                direction = "+" if tp.direction == "forward" else "-"
                 size = [0, self.width_ports, self.depth_ports]
-            elif fdtd_port.span[1] is None:  # y-axis injection
-                direction = "+" if fdtd_port.direction == "forward" else "-"
+            elif tp.span[1] is None:  # y-axis injection
+                direction = "+" if tp.direction == "forward" else "-"
                 size = [self.width_ports, 0, self.depth_ports]
             else:
-                raise ValueError(f"Invalid span configuration for port {fdtd_port.name}")
+                raise ValueError(f"Invalid span configuration for port {tp.name}")
 
             # Create Tidy3D Port object with multi-modal support
             port = Port(
-                center=fdtd_port.position,
+                center=tp.position,
                 size=size,
                 direction=direction,
-                name=fdtd_port.name,
+                name=tp.name,
                 mode_spec=td.ModeSpec(
                     num_modes=max(self.modes)
                 ),  # Ensure enough modes are calculated

--- a/src/gds_fdtd/solvers/base.py
+++ b/src/gds_fdtd/solvers/base.py
@@ -12,7 +12,7 @@ The Phase-3 solver contract. Every engine adapter implements:
 Constructors MUST be cheap and pure: no disk writes, no network, no license
 checks — the remote-compute invariant: a JobSpec must be buildable anywhere.
 The Tidy3D adapter's scene-building engine base lives in the internal
-``solvers._engine_base`` module.
+``solvers._tidy3d_base`` module.
 """
 
 from __future__ import annotations

--- a/src/gds_fdtd/solvers/lumerical.py
+++ b/src/gds_fdtd/solvers/lumerical.py
@@ -4,11 +4,11 @@ gds_fdtd simulation toolbox.
 LumericalSolver: the Ansys Lumerical FDTD adapter on the Phase-3 Solver
 contract. ``build()`` generates the COMPLETE setup script (.lsf) as
 pure text plus the exported GDS — offline, deterministic, no license, no
-lumapi import — mirroring the validated legacy ``fdtd_solver_lumerical``
-semantics (incl. the F6/F7 Lumerical-2025 fixes). ``run()`` is the only
-method that opens a lumapi session (license checkout).
+lumapi import — mirroring the original validated Lumerical setup flow (incl.
+the F6/F7 Lumerical-2025 fixes). ``run()`` is the only method that opens a
+lumapi session (license checkout).
 
-Unlike the legacy layer-builder flow (which asked the live session which GDS
+Unlike the original layer-builder flow (which asked the live session which GDS
 layers exist), the script generator derives the present layers from the
 component's structures — one reason build() needs no session.
 """

--- a/src/gds_fdtd/solvers/tidy3d.py
+++ b/src/gds_fdtd/solvers/tidy3d.py
@@ -3,9 +3,8 @@ gds_fdtd simulation toolbox.
 
 Tidy3DSolver: the tidy3d (>=2.11) adapter on the Phase-3 Solver contract.
 Scene construction runs inside ``build()`` via the internal
-``_tidy3d_engine`` module (shared with the deprecated ``fdtd_solver_tidy3d``
-public alias); the constructor stays pure per the contract, and ``run()`` is
-the only method that talks to the tidy3d cloud.
+``_tidy3d_engine`` module; the constructor stays pure per the contract, and
+``run()`` is the only method that talks to the tidy3d cloud.
 """
 
 from __future__ import annotations

--- a/src/gds_fdtd/spec.py
+++ b/src/gds_fdtd/spec.py
@@ -2,12 +2,12 @@
 gds_fdtd simulation toolbox.
 
 SimulationSpec: one validated pydantic model for every numeric
-simulation setting that was previously ~15 loose solver kwargs. Defaults are
-IDENTICAL to the historical fdtd_solver defaults. All lengths are um, angles
-degrees, frequencies Hz (package-wide convention).
+simulation setting that was previously ~15 loose solver kwargs. Defaults match
+the original solver defaults. All lengths are um, angles degrees, frequencies
+Hz (package-wide convention).
 
-The legacy fdtd_solver consumes this via a thin adapter (its keyword surface
-is unchanged); the Phase-3 Solver ABC takes a SimulationSpec directly.
+The Tidy3D scene-building engine consumes these settings via its keyword
+surface; the Phase-3 Solver ABC takes a SimulationSpec directly.
 """
 
 from __future__ import annotations

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1,4 +1,4 @@
-"""Tests for the internal engine base (solvers._engine_base)."""
+"""Tests for the internal Tidy3D engine base (solvers._tidy3d_base)."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ import pytest
 from gds_fdtd.core import parse_yaml_tech
 from gds_fdtd.lyprocessor import load_cell
 from gds_fdtd.simprocessor import load_component_from_tech
-from gds_fdtd.solvers._engine_base import fdtd_port, fdtd_solver
+from gds_fdtd.solvers._tidy3d_base import _TidyEngineBase, _TidyPort
 
 TESTS_DIR = pathlib.Path(__file__).parent
 
@@ -24,9 +24,10 @@ def escalator_component():
 
 
 def _make_solver(comp, tmp_path, **kwargs):
-    # fdtd_solver's "abstract" methods don't use ABCMeta, so the base class is
-    # directly instantiable — which conveniently exercises the full base __init__.
-    return fdtd_solver(component=comp, tech=None, working_dir=str(tmp_path), **kwargs)
+    # _TidyEngineBase's "abstract" methods don't use ABCMeta, so the base class
+    # is directly instantiable — which conveniently exercises the full base
+    # __init__ without needing tidy3d.
+    return _TidyEngineBase(component=comp, tech=None, working_dir=str(tmp_path), **kwargs)
 
 
 # ---------- B5: port_input default ----------
@@ -72,9 +73,9 @@ def test_solver_instances_share_no_mutable_state(escalator_component, tmp_path):
     assert s2.field_monitors == ["z"]
 
 
-def test_fdtd_port_instances_share_no_mutable_state():
-    p1 = fdtd_port(name="opt1")
-    p2 = fdtd_port(name="opt2")
+def test_tidy_port_instances_share_no_mutable_state():
+    p1 = _TidyPort(name="opt1")
+    p2 = _TidyPort(name="opt2")
     p1.position[0] = 123.0
     p1.modes.append(7)
     p1.span[1] = 99.0

--- a/tests/test_solver_tidy3d.py
+++ b/tests/test_solver_tidy3d.py
@@ -16,7 +16,7 @@ td = pytest.importorskip("tidy3d")
 from gds_fdtd.core import parse_yaml_tech  # noqa: E402
 from gds_fdtd.lyprocessor import load_cell  # noqa: E402
 from gds_fdtd.simprocessor import load_component_from_tech  # noqa: E402
-from gds_fdtd.solvers._tidy3d_engine import _TidyEngine as fdtd_solver_tidy3d  # noqa: E402
+from gds_fdtd.solvers._tidy3d_engine import _TidyEngine  # noqa: E402
 
 TESTS_DIR = pathlib.Path(__file__).parent
 
@@ -26,7 +26,7 @@ def solver(tmp_path_factory):
     tech = parse_yaml_tech(str(TESTS_DIR / "tech_tidy3d.yaml"))
     cell, layout = load_cell(str(TESTS_DIR / "si_sin_escalator.gds"))
     comp = load_component_from_tech(cell=cell, tech=tech)
-    s = fdtd_solver_tidy3d(
+    s = _TidyEngine(
         component=comp,
         tech=tech,
         boundary=["PML", "Metal", "Periodic"],  # deliberately mixed (B10)
@@ -51,7 +51,7 @@ def test_unknown_boundary_raises():
     cell, layout = load_cell(str(TESTS_DIR / "si_sin_escalator.gds"))
     comp = load_component_from_tech(cell=cell, tech=tech)
     with pytest.raises(ValueError, match="Unsupported boundary"):
-        fdtd_solver_tidy3d(
+        _TidyEngine(
             component=comp, tech=tech, boundary=["PML", "PML", "Bogus"], working_dir="/tmp"
         )
     del layout

--- a/tests/test_solver_tidy3d.py
+++ b/tests/test_solver_tidy3d.py
@@ -51,9 +51,7 @@ def test_unknown_boundary_raises():
     cell, layout = load_cell(str(TESTS_DIR / "si_sin_escalator.gds"))
     comp = load_component_from_tech(cell=cell, tech=tech)
     with pytest.raises(ValueError, match="Unsupported boundary"):
-        _TidyEngine(
-            component=comp, tech=tech, boundary=["PML", "PML", "Bogus"], working_dir="/tmp"
-        )
+        _TidyEngine(component=comp, tech=tech, boundary=["PML", "PML", "Bogus"], working_dir="/tmp")
     del layout
 
 

--- a/tests/test_solver_tidy3d_mocked.py
+++ b/tests/test_solver_tidy3d_mocked.py
@@ -40,7 +40,7 @@ def escalator(fake_td):
 
 
 def _make(escalator, tmp_path, **kwargs):
-    from gds_fdtd.solvers._tidy3d_engine import _TidyEngine as fdtd_solver_tidy3d
+    from gds_fdtd.solvers._tidy3d_engine import _TidyEngine
 
     comp, tech = escalator
     defaults = {
@@ -53,7 +53,7 @@ def _make(escalator, tmp_path, **kwargs):
         "working_dir": str(tmp_path),
     }
     defaults.update(kwargs)
-    return fdtd_solver_tidy3d(**defaults)
+    return _TidyEngine(**defaults)
 
 
 def test_setup_constructs_scene_offline(fake_td, escalator, tmp_path):

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -50,8 +50,8 @@ def test_extra_keys_rejected():
         SimulationSpec(mesh_size=5)
 
 
-def test_legacy_solver_exposes_spec(tmp_path):
-    """The fdtd_solver adapter builds a spec and mirrors it into legacy attrs."""
+def test_engine_base_exposes_spec(tmp_path):
+    """The Tidy3D engine base builds a spec and mirrors it into legacy attrs."""
     import pathlib
 
     from gds_fdtd.core import parse_yaml_tech


### PR DESCRIPTION
## Why
The pre-0.5 generic engine classes `fdtd_solver` / `fdtd_port` were the **last `fdtd_solver*` names in the tree**. They read as leftover legacy on every `grep fdtd_solver` — even though after the 0.6 removal they are internal and only the Tidy3D engine uses them (the Lumerical adapter is native). This finishes the strangler-fig migration for the tidy3d side.

## What
- `fdtd_solver` → `_TidyEngineBase`, `fdtd_port` → `_TidyPort`
- module `solvers/_engine_base.py` → `solvers/_tidy3d_base.py` (git rename, history preserved)
- engine base no longer imports the **legacy `core.technology`** type — it receives the modern `Technology` in practice (the adapter passes `self.technology`, which has `.to_legacy_dict()`), so the old hint was actually wrong
- `fdtd_ports` attr / `_convert_component_ports_to_fdtd_ports` → `tidy_ports` / `_build_tidy_ports`
- refreshed stale docstrings referencing the removed public aliases (`spec`, `lumerical`, `tidy3d`, `base`)
- CHANGELOG: dropped the contradictory `### Deprecated` block (it listed classes as "deprecated, removed in 1.0" that the same release **Removed** in 0.6)

## What did NOT change
- **No public API.** Every renamed name is underscore-internal.
- The base stays a **separate class** so its tidy3d-independent setup logic remains importable and testable **without tidy3d installed** (`tests/test_solver.py` exercises it offline). A full collapse into `_TidyEngine` would have coupled that logic to tidy3d — rejected on purpose.

## Verification
- `grep 'fdtd_solver|fdtd_port'` now only hits accurate "removed in 0.6" history notes
- full offline test suite green; touched tests (base, spec, mocked tidy3d) run (not skipped) — 29 passed
- `ruff` clean; `mypy --strict` green on all 15 required core files