### PR TITLE
Legacy cleanup 3/5: rename to_legacy_dict → to_solver_dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The legacy dict-flavored `gds_fdtd.core.technology` class (and its
   `from gds_fdtd import technology` re-export) was removed. Use the validated
   `gds_fdtd.technology.Technology` model (`Technology.from_yaml(...)`); its
-  `.to_legacy_dict()` reproduces the old dict shape if you need it. Nothing
+  `.to_solver_dict()` reproduces the old dict shape if you need it. Nothing
   inside the package used the class.
 - Dead code: the internal Tidy3D engine's unused results path
   (`run`/`get_resources`/`get_results`/`get_log`/`visualize_field_monitors`
@@ -41,10 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   engine only builds the scene. This also removes the engine's last dependency
   on the legacy `sparams` module.
 - `gds_fdtd.core.parse_yaml_tech` was removed. It was a one-line bridge to
-  `Technology.from_yaml(path).to_legacy_dict()`; call sites now use
+  `Technology.from_yaml(path).to_solver_dict()`; call sites now use
   `gds_fdtd.technology.Technology.from_yaml(path)` directly and pass the
   `Technology` to `load_component_from_tech`/`load_device`/the solvers (all of
-  which accept it). Use `.to_legacy_dict()` if you specifically need the dict.
+  which accept it). Use `.to_solver_dict()` if you specifically need the dict.
 - Removed the stray pre-0.5 `examples/notebooks/faid/` notebook (unreferenced,
   superseded by the standardized `examples/0X_*` set; it had also once logged a
   license token).
@@ -63,6 +63,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.dat` fuzz target).
 
 ### Changed
+- (BREAKING) Renamed the technology-to-dict method: `Technology.to_legacy_dict()`
+  → `Technology.to_solver_dict()`, and the per-material `MaterialSpec.to_legacy()`
+  → `MaterialSpec.to_solver_dict()`. The returned schema-v1 dict — consumed by the
+  simprocessor, the gdsfactory bridge, the CLI, and the tidy3d/lumerical/beamz
+  adapters — is unchanged; only the misleading "legacy" name is gone. No
+  deprecation alias (consistent with the rest of this 0.6.0 cleanup). Migration:
+  replace `tech.to_legacy_dict()` with `tech.to_solver_dict()`.
 - The Tidy3D scene-building engine is now fully internal and honestly named.
   The generic `fdtd_solver`/`fdtd_port` engine classes (the last pre-0.5 names
   in the tree) were renamed to `_TidyEngineBase`/`_TidyPort`, and the module

--- a/src/gds_fdtd/cli.py
+++ b/src/gds_fdtd/cli.py
@@ -229,7 +229,7 @@ def cmd_convert_tech(args) -> int:
         named[name] = mat
         return name
 
-    legacy = tech.to_legacy_dict()
+    legacy = tech.to_solver_dict()
     doc: dict = {
         "name": legacy["name"],
         "schema_version": 2,
@@ -261,7 +261,7 @@ def cmd_convert_tech(args) -> int:
     with open(out_path, "w") as f:
         yaml.safe_dump({"technology": doc}, f, sort_keys=False, default_flow_style=None)
     # round-trip guard: the emitted v2 must reproduce the v1 legacy dict
-    converted = Technology.from_yaml(out_path).to_legacy_dict()
+    converted = Technology.from_yaml(out_path).to_solver_dict()
     if converted != legacy:
         _emit({"error": f"round-trip mismatch writing {out_path}"}, args.json)
         return EXIT_INVALID

--- a/src/gds_fdtd/grid.py
+++ b/src/gds_fdtd/grid.py
@@ -71,8 +71,8 @@ def resolve_index(material: Any, wavelength_um: float) -> complex:
     if isinstance(material, (int, float, complex)) and not isinstance(material, bool):
         return complex(material)
 
-    if hasattr(material, "to_legacy"):  # pydantic MaterialSpec
-        material = material.to_legacy()
+    if hasattr(material, "to_solver_dict"):  # pydantic MaterialSpec
+        material = material.to_solver_dict()
 
     if isinstance(material, dict):
         if "nk" in material:

--- a/src/gds_fdtd/layout/gdsfactory.py
+++ b/src/gds_fdtd/layout/gdsfactory.py
@@ -75,7 +75,7 @@ def from_gdsfactory(c, tech, z_span: float = 4.0) -> Component:
             "gdsfactory is not installed. Install with: pip install gds_fdtd[gdsfactory]"
         ) from e
 
-    tech_dict = tech.to_legacy_dict() if hasattr(tech, "to_legacy_dict") else tech
+    tech_dict = tech.to_solver_dict() if hasattr(tech, "to_solver_dict") else tech
     device_layers = {tuple(d["layer"]): d for d in tech_dict["device"]}
 
     # ---- structures: one per polygon per tech-declared device layer ----

--- a/src/gds_fdtd/simprocessor.py
+++ b/src/gds_fdtd/simprocessor.py
@@ -140,7 +140,7 @@ def _load_tidy3d_material(material_spec: dict):
 
 def load_component_from_tech(cell, tech, z_span=4, z_center=None):
     # Accept either a Technology model or an already-materialized legacy dict.
-    tech_dict = tech.to_legacy_dict() if hasattr(tech, "to_legacy_dict") else tech
+    tech_dict = tech.to_solver_dict() if hasattr(tech, "to_solver_dict") else tech
 
     # load the structures in the device
     device_wg = []

--- a/src/gds_fdtd/solvers/beamz.py
+++ b/src/gds_fdtd/solvers/beamz.py
@@ -126,7 +126,7 @@ class BeamzSolver(Solver):
         t = self.technology
         if t is None:
             return None
-        return t.to_legacy_dict() if hasattr(t, "to_legacy_dict") else t
+        return t.to_solver_dict() if hasattr(t, "to_solver_dict") else t
 
     def _device_layer(self) -> dict | None:
         """The single device layer present in the component (v1 restriction)."""

--- a/src/gds_fdtd/solvers/lumerical.py
+++ b/src/gds_fdtd/solvers/lumerical.py
@@ -109,7 +109,7 @@ class LumericalSolver(Solver):
 
     def _tech_dict(self) -> dict:
         t = self.technology
-        return t.to_legacy_dict() if hasattr(t, "to_legacy_dict") else t
+        return t.to_solver_dict() if hasattr(t, "to_solver_dict") else t
 
     def build(self) -> SetupArtifacts:
         """Export the GDS and generate the full .lsf setup script (offline)."""

--- a/src/gds_fdtd/solvers/tidy3d.py
+++ b/src/gds_fdtd/solvers/tidy3d.py
@@ -67,8 +67,8 @@ class Tidy3DSolver(Solver):
             problems.append("Tidy3DSolver requires a technology (materials)")
         else:
             tech_dict = (
-                self.technology.to_legacy_dict()
-                if hasattr(self.technology, "to_legacy_dict")
+                self.technology.to_solver_dict()
+                if hasattr(self.technology, "to_solver_dict")
                 else self.technology
             )
             for i, d in enumerate(tech_dict.get("device", [])):

--- a/src/gds_fdtd/technology.py
+++ b/src/gds_fdtd/technology.py
@@ -11,7 +11,7 @@ frozen through the 1.x series). Additions in this module are additive-only:
 - optional ``rii:`` material source referencing the refractiveindex.info
   database (see gds_fdtd.materials.rii).
 
-``Technology.to_legacy_dict()`` reproduces exactly the dict shape the rest of
+``Technology.to_solver_dict()`` reproduces exactly the dict shape the rest of
 the package consumes today; the golden fixtures prove equivalence with the
 original parser.
 """
@@ -72,8 +72,8 @@ class MaterialSpec(BaseModel):
             raise ValueError("'tidy3d_db' must be a mapping containing 'nk' or 'model'")
         return v
 
-    def to_legacy(self) -> dict[str, Any]:
-        """The raw mapping shape the legacy dict flow carries for materials."""
+    def to_solver_dict(self) -> dict[str, Any]:
+        """The solver-facing dict mapping for one material (per-solver hints + neutral nk/rii)."""
         out: dict[str, Any] = {}
         if self.tidy3d_db is not None:
             out["tidy3d_db"] = self.tidy3d_db
@@ -286,7 +286,7 @@ class Technology(BaseModel):
         except Exception as e:
             raise ValueError(f"Invalid technology file {file_path}: {e}") from e
 
-    def to_legacy_dict(self) -> dict[str, Any]:
+    def to_solver_dict(self) -> dict[str, Any]:
         """The schema-v1 dict shape the solver adapters and simprocessor consume."""
         return {
             "name": self.name,
@@ -294,14 +294,14 @@ class Technology(BaseModel):
                 {
                     "z_base": self.substrate.z_base,
                     "z_span": self.substrate.z_span,
-                    "material": self.substrate.material.to_legacy(),
+                    "material": self.substrate.material.to_solver_dict(),
                 }
             ],
             "superstrate": [
                 {
                     "z_base": self.superstrate.z_base,
                     "z_span": self.superstrate.z_span,
-                    "material": self.superstrate.material.to_legacy(),
+                    "material": self.superstrate.material.to_solver_dict(),
                 }
             ],
             "pinrec": [{"layer": list(layer)} for layer in self.pinrec],
@@ -311,7 +311,7 @@ class Technology(BaseModel):
                     "layer": list(d.layer),
                     "z_base": d.z_base,
                     "z_span": d.z_span,
-                    "material": d.material.to_legacy(),
+                    "material": d.material.to_solver_dict(),
                     "sidewall_angle": d.sidewall_angle,
                 }
                 for d in self.device

--- a/tests/conformance/test_solver_contract.py
+++ b/tests/conformance/test_solver_contract.py
@@ -111,13 +111,13 @@ def _make_job(cls):
         # AGNOSTIC setup (owner directive): the unified tech carries neutral
         # nk entries and from_gdsfactory attaches the source component, so
         # beamz needs NO solver-specific kwargs.
-        tech_dict = Technology.from_yaml(str(TESTS_DIR / "tech_unified.yaml")).to_legacy_dict()
+        tech_dict = Technology.from_yaml(str(TESTS_DIR / "tech_unified.yaml")).to_solver_dict()
         gf_c = gf.components.straight(length=5)
         comp = from_gdsfactory(gf_c, tech_dict)
         return comp, tech_dict, None, {}
 
     tech_file = "tech_tidy3d.yaml" if cls.name == "tidy3d" else "tech_lumerical.yaml"
-    tech_dict = Technology.from_yaml(str(TESTS_DIR / tech_file)).to_legacy_dict()
+    tech_dict = Technology.from_yaml(str(TESTS_DIR / tech_file)).to_solver_dict()
     cell, layout = load_cell(str(TESTS_DIR / "si_sin_escalator.gds"))
     comp = load_component_from_tech(cell=cell, tech=tech_dict)
     technology = tech_dict if cls.name != "fake" else None

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -816,14 +816,14 @@ def _common_assertions(parsed: dict[str, Any]) -> None:
 
 
 def test_parse_yaml_tidy3d(tidy3d_yaml: str) -> None:
-    parsed = Technology.from_yaml(tidy3d_yaml).to_legacy_dict()
+    parsed = Technology.from_yaml(tidy3d_yaml).to_solver_dict()
     _common_assertions(parsed)
     # material dict carries tidy3d_db key
     assert "tidy3d_db" in parsed["device"][0]["material"]
 
 
 def test_parse_yaml_lumerical(lumerical_yaml: str) -> None:
-    parsed = Technology.from_yaml(lumerical_yaml).to_legacy_dict()
+    parsed = Technology.from_yaml(lumerical_yaml).to_solver_dict()
     _common_assertions(parsed)
     # material dict carries lum_db key
     assert "lum_db" in parsed["device"][0]["material"]

--- a/tests/test_gdsfactory.py
+++ b/tests/test_gdsfactory.py
@@ -80,7 +80,7 @@ def test_bend_circular_smoke(tech):
 def test_component_without_tech_layers_raises(tech):
     import copy
 
-    bad_tech = copy.deepcopy(tech.to_legacy_dict())
+    bad_tech = copy.deepcopy(tech.to_solver_dict())
     for d in bad_tech["device"]:
         d["layer"] = [42, 7]
     with pytest.raises(ValueError, match="no polygons on any technology device layer"):

--- a/tests/test_solvers_adapters.py
+++ b/tests/test_solvers_adapters.py
@@ -89,7 +89,7 @@ def test_lum_validate_flags_missing_materials():
     import copy
 
     comp, tech, layout = _job("tech_lumerical.yaml")
-    bad = copy.deepcopy(tech.to_legacy_dict())
+    bad = copy.deepcopy(tech.to_solver_dict())
     for d in bad["device"]:
         d["material"].pop("lum_db", None)
     solver = get_solver("lumerical")(comp, technology=bad)
@@ -140,7 +140,7 @@ def test_beamz_resolves_index_from_rii(tmp_path, monkeypatch):
 
     monkeypatch.setenv("GDS_FDTD_RII_DB", str(_pl.Path(__file__).parent / "rii_db"))
     comp, tech, layout = _job("tech_tidy3d.yaml")
-    rii_tech = copy.deepcopy(tech.to_legacy_dict())
+    rii_tech = copy.deepcopy(tech.to_solver_dict())
     # v1 needs exactly ONE device layer present: keep [1,0] only, rii material
     rii_tech["device"] = [rii_tech["device"][0]]
     rii_tech["device"][0]["material"] = {"rii": {"shelf": "main", "book": "Si", "page": "Li-293"}}

--- a/tests/test_technology.py
+++ b/tests/test_technology.py
@@ -22,13 +22,13 @@ def test_all_shipped_tech_files_load(path):
     tech = Technology.from_yaml(path)
     assert tech.schema_version in (1, 2)  # examples/tech.yaml is the v2 reference
     assert tech.device and tech.pinrec and tech.devrec
-    legacy = tech.to_legacy_dict()
+    legacy = tech.to_solver_dict()
     assert set(legacy) == {"name", "substrate", "superstrate", "pinrec", "devrec", "device"}
 
 
 def test_legacy_dict_matches_old_parser_shape(tmp_path):
-    """Technology.to_legacy_dict() reproduces the old parser's shape exactly."""
-    d = Technology.from_yaml(str(TESTS_DIR / "tech_tidy3d.yaml")).to_legacy_dict()
+    """Technology.to_solver_dict() reproduces the old parser's shape exactly."""
+    d = Technology.from_yaml(str(TESTS_DIR / "tech_tidy3d.yaml")).to_solver_dict()
     assert d["device"][0]["layer"] == [1, 0]
     assert d["device"][0]["sidewall_angle"] == 85
     assert isinstance(d["substrate"], list) and len(d["substrate"]) == 1
@@ -106,7 +106,7 @@ def test_rii_material_loads_offline_and_matches_silicon(tmp_path):
     assert mat.k_at(1.55) == 0.0
     assert mat.nk_at(1.55) == pytest.approx(3.4757 + 0j, abs=0.05)
     # legacy dict carries the rii mapping through
-    legacy = tech.to_legacy_dict()
+    legacy = tech.to_solver_dict()
     assert legacy["device"][0]["material"]["rii"] == {
         "shelf": "main",
         "book": "Si",

--- a/tests/test_technology_v2.py
+++ b/tests/test_technology_v2.py
@@ -64,8 +64,8 @@ def v2_file(tmp_path):
 def test_v2_equals_v1_unified(v2_file):
     """The v2 doc above is the named-materials form of tech_unified.yaml —
     both must produce the IDENTICAL legacy dict (equivalence by construction)."""
-    v1 = Technology.from_yaml(TESTS_DIR / "tech_unified.yaml").to_legacy_dict()
-    v2 = Technology.from_yaml(v2_file).to_legacy_dict()
+    v1 = Technology.from_yaml(TESTS_DIR / "tech_unified.yaml").to_solver_dict()
+    v2 = Technology.from_yaml(v2_file).to_solver_dict()
     assert v2 == v1
 
 
@@ -123,5 +123,5 @@ def test_convert_tech_cli_roundtrip(tmp_path):
     assert doc["schema_version"] == 2
     # SiO2 appears twice in v1 (substrate + superstrate) -> ONE named material
     assert len(doc["materials"]) == 3
-    v1 = Technology.from_yaml(TESTS_DIR / "tech_unified.yaml").to_legacy_dict()
-    assert Technology.from_yaml(out).to_legacy_dict() == v1
+    v1 = Technology.from_yaml(TESTS_DIR / "tech_unified.yaml").to_solver_dict()
+    assert Technology.from_yaml(out).to_solver_dict() == v1


### PR DESCRIPTION
**Stage 3 of 5** in the legacy removal. A pure **rename** — zero behavior change, the returned dict shape is byte-for-byte identical.

## What
`to_legacy_dict` was a misleading name: the method is not going away, it produces the **solver-facing schema-v1 dict** that the simprocessor, the gdsfactory bridge, the CLI, and all three adapters (tidy3d/lumerical/beamz) actually consume. Renamed to say so:

- `Technology.to_legacy_dict()` → **`Technology.to_solver_dict()`**
- `MaterialSpec.to_legacy()` → **`MaterialSpec.to_solver_dict()`** — the material-level analog (called internally + by `grid.resolve_index` through a `hasattr` guard)
- every call site updated, **including the two string-literal `hasattr` guards** (`grid.py`, `solvers/tidy3d.py`) that a symbol-only rename would silently miss
- all tests migrated; the three now-stale CHANGELOG migration notes fixed, and a `(BREAKING)` bullet added under `### Changed`

## Decisions
- **Hard rename, no deprecation alias** — consistent with stage 2's `parse_yaml_tech` removal and the rest of this documented-breaking 0.6.0 cleanup. Migration is one token: `.to_legacy_dict()` → `.to_solver_dict()`.
- **Kept the dual-accept `Technology`-or-raw-dict shim** (`... if hasattr(...) else <dict>`); removing it is a separate concern, not this stage.

## Verification
- Offline suite green **both** dev-only **and** with the `gdsfactory`+`beamz` extras installed (the all-extras leg — where stage 2's missed dict-users surfaced).
- `ruff check` + `ruff format --check` + `codespell` clean.
- `mypy --strict` clean on all 15 gated modules (`technology.py` and `grid.py` are in the required set).
- `git grep` confirms **zero** residual `to_legacy_dict`/`to_legacy` references in code (the only remaining hits are the intentional old-name mentions in the CHANGELOG migration note).

Net: 15 files, +42 / −35.

## Next stages
4. geometry `__getattr__` shims + `core.py`
5. `sparams` → internal `_dat` helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)
