### PR TITLE
Legacy cleanup 5/5: internalize sparams -> private _sparams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `component`→`Component`, `layout`→`LayoutSource`); the non-deprecated helpers
   (`c0_um`, `calculate_polygon_extension`, `initialize_ports_z`,
   `is_point_inside_polygon`) are exported from `gds_fdtd.geometry` too.
+- The `gds_fdtd.sparams` module is no longer public — it moved to the internal
+  `gds_fdtd._sparams` (the legacy `sparameters` container + INTERCONNECT `.dat`
+  reader/writer). The supported surface is the `SMatrix` API (`SMatrix.from_dat`/
+  `to_dat`, `from_hdf5`/`to_hdf5`, `from_npz`/`to_npz`, `to_touchstone`);
+  `import gds_fdtd.sparams` now raises `ModuleNotFoundError`.
 - Removed the stray pre-0.5 `examples/notebooks/faid/` notebook (unreferenced,
   superseded by the standardized `examples/0X_*` set; it had also once logged a
   license token).

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -41,9 +41,9 @@ Core modules
     ``SimulationSpec`` — every numeric simulation setting, validated, in
     package-wide units (µm / degrees / Hz).
 
-``smatrix`` / ``sparams``
-    The canonical ``SMatrix`` container plus the Lumerical-format ``.dat``
-    reader/writer it interoperates with.
+``smatrix``
+    The canonical ``SMatrix`` container plus the internal Lumerical-format
+    ``.dat`` reader/writer (``_sparams``) it interoperates with.
 
 Solver layer
 ------------

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -7,5 +7,4 @@ API Reference
 
    gds_fdtd.lyprocessor
    gds_fdtd.simprocessor
-   gds_fdtd.sparams
    gds_fdtd.logging_config

--- a/fuzz/fuzz_dat.py
+++ b/fuzz/fuzz_dat.py
@@ -1,7 +1,7 @@
 """Fuzz target: Lumerical INTERCONNECT ``.dat`` S-parameter parsing.
 
 Feeds arbitrary bytes to ``SMatrix.from_dat`` (the hand-written text parser
-in gds_fdtd.sparams). Malformed input must fail with a validation error,
+in gds_fdtd._sparams). Malformed input must fail with a validation error,
 never an unhandled crash.
 
 Run locally:  python fuzz/fuzz_dat.py -atheris_runs=20000

--- a/src/gds_fdtd/__init__.py
+++ b/src/gds_fdtd/__init__.py
@@ -13,7 +13,6 @@ from . import (
     lyprocessor,
     modes,
     simprocessor,
-    sparams,
     validation,
 )
 from .geometry import Component, LayoutSource, Port, Region, Structure
@@ -39,7 +38,6 @@ __all__ = [
     "lyprocessor",
     "modes",
     "simprocessor",
-    "sparams",
     "validation",
 ]
 

--- a/src/gds_fdtd/_sparams.py
+++ b/src/gds_fdtd/_sparams.py
@@ -1,7 +1,10 @@
 """
 gds_fdtd simulation toolbox.
 
-S-parameter module.
+Internal S-parameter helper (private module): the legacy ``sparameters``
+container and the Lumerical INTERCONNECT ``.dat`` reader/writer that
+``SMatrix.to_dat``/``from_dat`` and the Lumerical adapter delegate to. Not part
+of the public API — use ``gds_fdtd.smatrix.SMatrix``.
 @author: Mustafa Hammood, 2025
 """
 

--- a/src/gds_fdtd/smatrix.py
+++ b/src/gds_fdtd/smatrix.py
@@ -195,7 +195,7 @@ class SMatrix:
         Port names are mapped to numeric ids by their trailing digits (or by
         position when a name has none); NaN (unmeasured) paths are skipped.
         """
-        from .sparams import sparameters, write_dat
+        from ._sparams import sparameters, write_dat
 
         def _num(i: int) -> int:
             digits = "".join(ch for ch in self.port_names[i] if ch.isdigit())
@@ -226,7 +226,7 @@ class SMatrix:
     @classmethod
     def from_dat(cls, path: str, name: str | None = None) -> SMatrix:
         """Read a Lumerical INTERCONNECT .dat into an SMatrix."""
-        from .sparams import process_dat
+        from ._sparams import process_dat
 
         spar = process_dat(path, name=name, verbose=False)
         return cast("SMatrix", spar.to_smatrix(name=name))

--- a/src/gds_fdtd/solvers/lumerical.py
+++ b/src/gds_fdtd/solvers/lumerical.py
@@ -385,7 +385,7 @@ class LumericalSolver(Solver):
         finally:
             fdtd.close()
 
-        from ..sparams import process_dat
+        from .._sparams import process_dat
 
         spar = process_dat(dat_path, verbose=False)
         sm = spar.to_smatrix(name=self.component.name)

--- a/tests/recorded/README.md
+++ b/tests/recorded/README.md
@@ -12,7 +12,7 @@ zero cloud/license access. All files are scrubbed before commit
 
 Refresh procedure: with `TIDY3D_API_KEY` configured (`~/.tidy3d/config`), run a
 solver on `tests/si_sin_escalator.gds` + `tests/tech_tidy3d.yaml` (coarse mesh,
-few wavelengths), export via `sparameters.to_smatrix()` → `to_hdf5()`/`to_dat()`,
+few wavelengths), export the resulting `SMatrix` via `to_hdf5()`/`to_dat()`,
 re-run the scrub grep, and update this table.
 
 NOTE (finding F5): tidy3d 2.8.x requires numpy<2 (undeclared) and therefore a

--- a/tests/test_sparams.py
+++ b/tests/test_sparams.py
@@ -1,11 +1,11 @@
-"""Tests for gds_fdtd.sparams (started in WP1.3; grows with WP1.6)."""
+"""Tests for gds_fdtd._sparams (started in WP1.3; grows with WP1.6)."""
 
 from __future__ import annotations
 
 import pytest
 
+from gds_fdtd._sparams import _number_of, s, sparameters
 from gds_fdtd.geometry import Port
-from gds_fdtd.sparams import _number_of, s, sparameters
 
 
 def _entry(in_port, out_port, in_mode=1, out_mode=1):
@@ -94,7 +94,7 @@ def _make_multimode_sparams() -> sparameters:
 
 
 def test_dat_round_trip(tmp_path):
-    from gds_fdtd.sparams import process_dat, write_dat
+    from gds_fdtd._sparams import process_dat, write_dat
 
     spar = _make_multimode_sparams()
     path = tmp_path / "dut.dat"
@@ -114,7 +114,7 @@ def test_dat_round_trip(tmp_path):
 
 
 def test_write_dat_rejects_inconsistent_lengths(tmp_path):
-    from gds_fdtd.sparams import write_dat
+    from gds_fdtd._sparams import write_dat
 
     spar = sparameters("bad")
     e = _entry(in_port="opt1", out_port="opt2")

--- a/tests/test_sparams_recorded.py
+++ b/tests/test_sparams_recorded.py
@@ -13,7 +13,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
-from gds_fdtd.sparams import process_dat
+from gds_fdtd._sparams import process_dat
 
 RECORDED = pathlib.Path(__file__).parent / "recorded"
 


### PR DESCRIPTION
**Stage 5 of 5 — the final stage.** Internalizes the pre-0.5 S-parameter layer.

> ⛓️ **Stacked on #31** (base = `legacy-cleanup-4-remove-core`). GitHub will auto-retarget this to `main` once #31 merges. Review/merge order: #30 → #31 → #32.

## What
`sparams.py` held the legacy `sparameters` container (`s`/`port`/`_number_of`, `S`/`plot`/`to_smatrix` + excitation-analysis helpers) and the INTERCONNECT `.dat` reader/writer. The modern surface (`SMatrix.to_dat`/`from_dat`, the Lumerical adapter) delegates to it, but it was still a **public** module. This makes it internal — nothing user-facing depends on the module path.

- **`git mv src/gds_fdtd/sparams.py → src/gds_fdtd/_sparams.py`** (tracked as a rename; verbatim move + an internal-only module docstring)
- dropped `sparams` from `__init__` / `__all__` and from the `docs/modules.rst` autosummary
- rewired the importers: `smatrix.py` (`to_dat`/`from_dat`) and `solvers/lumerical.py` → `._sparams`
- tests import from `gds_fdtd._sparams`; **test filenames kept** (so `test_smatrix.py`'s `from tests.test_sparams import …` cross-import stays valid — zero extra churn)
- reworded `docs/architecture.rst`, `fuzz/fuzz_dat.py` + `tests/recorded/README.md` prose; `CHANGELOG` gets a `Removed (BREAKING)` bullet

## Decisions
- **Name `_sparams`, not `_dat`** — the module is the `sparameters` container (the `.dat` I/O is a minority), so `_sparams` is scope-faithful and a one-char rename (keeps the test filenames + cross-import untouched).
- **Pure rename, no trimming.** The `plot()` and excitation-analysis methods look like dead legacy code but are covered by `test_sparams_recorded.py`, so they moved verbatim.
- **Hard rename, no shim** — `import gds_fdtd.sparams` → `ModuleNotFoundError` (intended 0.6.0 break; the supported surface is the `SMatrix` API).
- **Left untouched:** the Lumerical LSF `"sparams"` sweep-name strings / `.fsp` paths in `lumerical.py` (not the Python module), and `docs/sparameters.rst` (pre-existing stale-prose about the removed `solver.sparameters` API — separate doc debt).

## Verification
- Suite green with `gdsfactory`+`beamz` extras: **283 passed / 15 skipped**, coverage **82.72%** (unchanged vs stage 4 — pure rename). The recorded `.dat` round-trip + `to_smatrix`/`from_dat` tests are the key exercise.
- `ruff` + `ruff format` + `codespell` + full `prek` clean.
- `mypy --strict` clean on all 15 gated modules.
- **Fresh `sphinx-build` clean** — no `gds_fdtd.sparams` autosummary page, no import failure (verified after clearing the git-ignored stale `_autosummary` stub, as a fresh CI checkout would).
- `git grep` confirms zero public `gds_fdtd.sparams` importers remain.

Net: 11 files, +22 / −17.

## Series complete
This closes the 5-stage legacy-cleanup: `1` dead code · `2` `parse_yaml_tech` · `3` `to_solver_dict` · `4` `core.py` · `5` `sparams`. 🎉
