### PR TITLE
docs: 0.6.0 documentation refresh + development handoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,10 +21,9 @@ uv run codespell src tests README.md
    the conformance suite (`tests/conformance/`) enforces this; don't weaken it.
 3. **Validate through the exact artifact users execute** (example file, fresh
    interpreter), not through bespoke scripts that share your session's import
-   state — see finding F10 in `MODERNIZATION_PLAN.md`.
-4. **Keep `MODERNIZATION_PLAN.md` current** if you execute roadmap work: the
-   scoreboard, findings, and deviations are the hand-off protocol between
-   agents.
+   state — see finding F10 (the tidy3d.web lazy-import crash) in `CHANGELOG.md`.
+4. **Keep `ROADMAP.md` current** if you execute roadmap work: it is the living
+   plan and the hand-off protocol between contributors.
 5. Recorded artifacts under `tests/recorded/` must be sanitized (no license
    tokens, hostnames, API keys) — grep before committing.
 6. All GitHub Actions must be pinned by full commit SHA.
@@ -35,8 +34,8 @@ uv run codespell src tests README.md
   beamz adapters), canonical results in `smatrix.py`, Tier-B pipeline in
   `grid.py` / `modes.py` / `extraction.py`, orchestration in `convergence.py` /
   `caching.py` / `validation.py`.
-- `MODERNIZATION_PLAN.md` — the living roadmap + execution log; read Part −1
-  (scoreboard) first.
+- `ROADMAP.md` — the living plan; read "Where we are" first. `HANDOFF.md` — the
+  development arc + the live-validation runbook (tidy3d/Lumerical).
 - `examples/` — every feature has a runnable example; each follows the
   standardized flow: geometry plot → validate/build/estimate → S-params plot →
   field plot.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ There is no version to bump (hatch-vcs derives it from the tag).
 
 These require admin permissions; PRs cannot change them:
 
-- [ ] Branch protection/ruleset on `main`: required checks `pass` + CodeQL,
+- [x] Branch protection/ruleset on `main`: required checks `pass` + CodeQL,
       linear history, no force pushes
 - [ ] Merge queue enabled with `pass` as its gate
 - [ ] Secret scanning + push protection enabled

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,127 @@
+# gds_fdtd — Development Handoff (0.6.0)
+
+**Audience:** the next engineer/agent, on a machine that **has** what this one did
+not — tidy3d cloud credits (`TIDY3D_API_KEY`), a Lumerical license (`lumapi` on
+path), and ideally a CUDA GPU. Your job is to run the **live validity checks** that
+could only be recorded, not re-run, here, and to verify the examples end-to-end.
+
+**State at handoff:** `main` carries the complete, breaking **0.6.0 legacy
+cleanup** (PRs #27–#32). Everything below was verified **offline** on macOS with
+the `dev`, `gdsfactory`, and `beamz` extras. Nothing that spends cloud credits,
+a license, or a GPU was executed. **The 0.6 changes were pure refactors
+(rename / move / remove) — no physics or numeric behavior changed** — but the
+engine-facing paths deserve a live re-check before tagging `v0.6.0`.
+
+---
+
+## 1. What gds_fdtd is (one screen)
+
+Turns a photonic-chip **GDS layout + a technology YAML + a `SimulationSpec`** into
+a 3D FDTD run on the engine of your choice, and returns one canonical S-matrix:
+
+```python
+from gds_fdtd.solvers import get_solver
+from gds_fdtd.spec import SimulationSpec
+
+solver  = get_solver("tidy3d" | "lumerical" | "beamz")(component, tech, SimulationSpec())
+smatrix = solver.run()          # the ONLY call that spends money / license / GPU
+```
+
+EDA-agnostic on the front (KLayout/SiEPIC, gdsfactory ≥9), solver-agnostic on the
+back. Same `(component, technology, spec)` in, same `SMatrix` out, on all engines.
+
+## 2. The development arc (0.1 → 0.6)
+
+| Version | What it was |
+|---|---|
+| **0.1–0.3** (2023–24) | Rough SiEPIC research scripts: `lum_tools.py` / `t3d_tools.py`, per-engine one-offs, PCell/CML helpers. |
+| **0.4.0** (2025-08) | First "architecture": a `fdtd_solver` base + `fdtd_solver_tidy3d` / `fdtd_solver_lumerical` + `fdtd_port`, `logging_config`, `sparams`. (Its changelog over-promised — Touchstone/JSON/energy checks were only *real* in 0.5.) |
+| **0.5.0** (2026-07-08, PR #23, ~73 commits) | **The solver-agnostic rewrite** (modernization Phases 0–7). `Solver` ABC contract, engine registry + entry points, canonical `SMatrix`, validated `SimulationSpec`, `Technology` schema v1/v2 + refractiveindex.info materials, Tier-B kernel pipeline (`grid`/`modes`/`extraction`), convergence/caching/cross-solver validation, serializable `JobSpec` + `gds-fdtd` CLI + backends, error hierarchy, settings, JSON logging. 19 audited legacy bugs (B-series) + findings F1–F14 fixed by live validation. Honest coverage (was a gamed ~100% over a 16% reality). Three-engine agreement recorded. |
+| post-0.5.0 | De-slop (PR #24); retired `MODERNIZATION_PLAN.md` → `ROADMAP.md`; Sigstore-signed releases + atheris fuzzing (WS5); `mypy --strict` expanded; **#27** flattened the tidy3d engine names (`fdtd_solver`/`fdtd_port` → `_TidyEngineBase`/`_TidyPort`). |
+| **0.6.0** (this arc, PRs #28–#32; **on `main`, not yet tagged**) | **Staged legacy cleanup — removed the entire pre-0.5 public surface.** See below. |
+
+### The 0.6.0 legacy cleanup (the 5 stages)
+1. **#28** — deleted dead code: `core.technology` class + the tidy3d engine's unused results path (dropped its last dependency on the legacy `sparams`).
+2. **#29** — removed `core.parse_yaml_tech`; every call site now uses `Technology.from_yaml(...)`.
+3. **#30** — renamed `Technology.to_legacy_dict()` → `to_solver_dict()` (and `MaterialSpec.to_legacy()` → `to_solver_dict()`).
+4. **#31** — removed the `gds_fdtd.core` PEP-562 shim module (the deprecated lowercase geometry names `port/structure/region/component/layout`).
+5. **#32** — internalized the public `gds_fdtd.sparams` module → private `gds_fdtd._sparams`.
+
+Earlier in the 0.6 line the deprecated `fdtd_solver_lumerical` / `fdtd_solver_tidy3d` classes and the `gds_fdtd.solver` module were also removed. **Net: the supported public API is now `get_solver(name)` + `Technology` + `SimulationSpec` + `SMatrix` (+ `geometry`, `lyprocessor`, `layout.gdsfactory`, `convergence`, `caching`, `validation`).** Full migration table in `CHANGELOG.md` under *[Unreleased] — targeting 0.6.0*.
+
+## 3. Architecture map (where things live)
+
+- **Layout ingestion:** `lyprocessor.py` (KLayout/SiEPIC pin+DevRec), `layout/gdsfactory.py` (gf ≥9). Ports auto-detected, never hand-placed. Primitives in `geometry.py` (`Port`/`Structure`/`Region`/`Component`, flat role-tagged structures).
+- **Technology:** `technology.py` (pydantic; YAML schema v1 inline + v2 named-materials; `to_solver_dict()` is the internal dict the adapters consume), `materials/rii.py` (offline refractiveindex.info reader).
+- **Contract:** `solvers/base.py` — `Solver` ABC (`validate`/`build`/`estimate` offline & free; **only `run()` spends**), `SolverCapabilities`, registry + `gds_fdtd.solvers` entry-point discovery.
+- **Settings & results:** `spec.py` (`SimulationSpec`), `smatrix.py` (`SMatrix`; `.dat`/Touchstone/HDF5/npz I/O delegates to the internal `_sparams.py`).
+- **Adapters:** `solvers/tidy3d.py` (+ internal `_tidy3d_base.py`, `_tidy3d_engine.py`), `solvers/lumerical.py` (offline `.lsf` generation + licensed run), `solvers/beamz.py` (JAX FDTD, free).
+- **Tier-B (kernel engines):** `grid.py` (permittivity rasterizer), `modes.py` (mode solver protocol + tidy3d local backend), `extraction.py` (mode-overlap S-params).
+- **Orchestration:** `convergence.py`, `caching.py` (`run_cached` job-hash cache), `validation.py` (`validate_across`), `execution/{jobspec,backends}.py`, `cli.py` (`gds-fdtd validate|build|estimate|run|convert|convert-tech|solvers`).
+- **Errors/logging/config:** `errors.py` (`GdsFdtdError` tree → CLI exit codes 0/2/3/4), `logging_config.py` (JSON-lines), `settings.py` (`GDS_FDTD_*` env).
+
+## 4. What is validated vs NOT (read this before trusting anything)
+
+**Verified offline this session** (macOS, `dev`+`gdsfactory`+`beamz`):
+- Full suite `-m "not physics and not gpu and not cloud and not licensed"`: **283 passed, coverage 82.72%** (config floor 75).
+- `mypy --strict` on the 15 gated modules; `ruff` + `ruff format`; `codespell`; full `prek` hooks; `sphinx-build` docs.
+
+**NOT run here (no credentials/hardware):**
+- **tidy3d cloud** (`cloud`/`physics` tests, `scripts/cloud_smoke.py`, `examples/01a,03a,03b,07a,08a-tidy3d`).
+- **Lumerical** (`licensed` tests, `examples/02a,02b,08a-lumerical`, the `lumerical-nightly` lane).
+- **GPU** (`gpu` tests; fdtdz; beamz-GPU).
+- **The three-engine agreement**: the artifacts in `tests/recorded/*.npz` (recorded **2026-07-07/08**, *before* the 0.6 flatten) are *replayed* offline every PR but were **not regenerated live** this arc. `SOLVER_STATUS.md` dates predate the cleanup — treat them as "last known good", not "verified post-0.6".
+
+## 5. Your validation runbook (ordered)
+
+Environment:
+```bash
+uv sync --extra dev --extra tidy3d --extra beamz --extra gdsfactory   # + prefab/siepic if testing 07/08
+# Lumerical: install Lumerical, put lumapi on PYTHONPATH.  tidy3d: export TIDY3D_API_KEY / ~/.tidy3d/config
+```
+
+0. **Baseline (offline, must be green — matches CI):**
+   `uv run pytest -m "not physics and not gpu and not cloud and not licensed"` → expect ~283 passed.
+1. **Examples end-to-end — the golden rule.** Per `ROADMAP.md` principle #1 and finding F10: run each example **as the exact committed artifact, in a fresh interpreter**, not via a shared session. Walk `examples/0X_*`: `01a`(t3d) `01b`(offline) `02a/02b`(lum) `03a/03b`(t3d) `04a-c` `05a`(gf) `06a-c`(beamz) `07a`(prefab) `08a`(siepic, t3d+lum) `09a`(offline) `10a`. Each should produce an `SMatrix` and the standard plots (geometry → S-params → fields). Confirm none import a removed symbol (they don't today — verified — but re-confirm after your env changes).
+2. **tidy3d cloud smoke:** `BUDGET_FC=0.5 uv run python scripts/cloud_smoke.py` (budget-gated; uploads → `estimate_cost` → deletes, aborts over budget, then runs & asserts physics). **Note:** this script was fixed this session — it previously imported the removed `parse_yaml_tech`; it now uses `Technology.from_yaml`. This is its first real run since that fix.
+3. **Lumerical:** run `examples/02`, `examples/08a_siepic_lumerical.py`; or wire the `lumerical-nightly` workflow to a self-hosted runner (`docs/self_hosted_runner.md`, set the `LUMERICAL_RUNNER` repo var).
+4. **Three-engine agreement (regenerate live):** rebuild `tests/recorded/straight_mesh10_{tidy3d,lumerical,beamz}.npz` from the same job; confirm tidy3d↔Lumerical within ~**0.0033 dB** and beamz within ~**0.052 dB**; `test_three_engine_agreement` (in `tests/test_recorded_artifacts.py`) must still pass against the refreshed data.
+5. **Refresh the record:** update `SOLVER_STATUS.md` (dates/versions/evidence) and the `tests/recorded/*` artifacts **in one PR**. **Sanitize first** — grep the artifacts for API keys, hostnames, license tokens (AGENTS.md rule #5).
+6. **Run the gated markers you now can:** `-m "physics"`, `-m "cloud"`, `-m "licensed"`, `-m "gpu"` (each spends the corresponding resource — see the guardrails).
+
+## 6. Repo conventions & guardrails (do not violate)
+
+- **Only `run()` spends** money/licenses/GPU. `validate`/`build`/`estimate` and all constructors stay offline, pure, deterministic — the conformance suite (`tests/conformance/`) enforces this; don't weaken it.
+- **Every change is a PR into `main`** — branch protection is ON (PR + green `pass` check + up-to-date branch + linear history; force-pushes blocked; admins enforced; **0 required reviews**, so a solo maintainer can self-merge, but the PR + CI path is mandatory). Strict up-to-date means you rebase/re-CI stacked PRs before each merge.
+- **Never commit secrets.** Recorded artifacts under `tests/recorded/` must be scrubbed.
+- **Commit identity:** author as the project owner's personal identity; do not attribute commits to an AI co-author.
+- **Validate through the artifact users run** (finding F10) — fresh interpreter, real files.
+- Docs build without the optional engines (`docs/conf.py` mocks tidy3d/lumapi/beamz/gdsfactory/prefab/SiEPIC/pya/jax).
+
+## 7. Where we stand (metrics)
+
+- **Version:** 0.6.0 line, **not yet tagged** (installed reports `0.5.1.dev…`; hatch-vcs derives the version from the git tag — tag `v0.6.0` to cut the release).
+- **Coverage:** 82.72% (all-extras leg; base floor enforced at 75). WS2 target is >90% on all-extras.
+- **CI:** full OS×Python matrix + all-extras leg + required `mypy --strict` core + `pass` gate + docs + atheris fuzz + Sigstore-signed release pipeline. All green on `main`.
+- **OpenSSF Scorecard ~7.0**, branch protection now enabled; the next lever is the **PyPI trusted publisher** (owner action → unlocks the Packaging check).
+
+## 8. Where to go next
+
+- **Tag `v0.6.0`** once the live validation (§5) passes and `SOLVER_STATUS.md` is refreshed.
+- **v1.0 lane:** freeze the public API + `__all__`; retire the last deprecation shim (`Component.structures` nested-list warning in `geometry.py`); write down the deprecation policy.
+- **WS1:** turn the 18 examples into executed notebooks (jupytext) with committed outputs + a docs gallery.
+- **Docs API reference:** `docs/modules.rst` autosummary is deliberately minimal. Expanding it to the full public surface (`smatrix`/`solvers`/`technology`/`spec`/`geometry`/…) first needs a module-docstring RST-hygiene pass — several modules (`convergence`, `extraction`, `validation`, `solvers/base`, `solvers/beamz`, `solvers/tidy3d`) use bare indented code examples (need `::` literal blocks) and `|S|²`/`|E|` (read as RST substitutions), which emit docutils warnings under autodoc. Do that pass, then expand + enable `sphinx-build -W`.
+- **WS2:** push all-extras coverage to >90% — the low spots are the engine adapters (`solvers/beamz`, `solvers/tidy3d`, `solvers/lumerical`) and `cli`/`caching`/`modes`; add real (small) beamz end-to-end tests and property-based tests on `SMatrix`/`geometry`/`technology`.
+- **WS4/WS5:** codecov project/patch PR gates; PyPI trusted publisher (owner); merge queue; CII-Best-Practices badge.
+- **Feature menu:** fdtdz adapter (free GPU; the rasterize→modes→extraction pipeline is built and tested, blocked only on GPU hardware), parameter sweeps/optimization, `scikit-rf` interop, a small PDK of reference devices with known-good S-params.
+
+Full detail + backlog rationale in **`ROADMAP.md`**; per-engine last-verified status in **`SOLVER_STATUS.md`**; AI-contributor rules in **`AGENTS.md`**.
+
+## 9. Gotchas / non-obvious
+
+- `gds_fdtd.sparams` and `gds_fdtd.core` are **gone** (→ internal `_sparams`, and geometry classes live in `gds_fdtd.geometry`). `import gds_fdtd.sparams`/`.core` raises `ModuleNotFoundError`. Use the `SMatrix` API for `.dat`/Touchstone/HDF5/npz.
+- The `"sparams"` strings in `solvers/lumerical.py` are the **Lumerical INTERCONNECT sweep name / `.fsp` path**, not the Python module — don't touch them.
+- `Technology.to_solver_dict()` returns the internal schema-v1 dict; the loader and adapters accept **either** a `Technology` model or that dict.
+- Ports must face 0/90/180/270°. beamz v1 is single-mode TE and rejects y-facing ports (finding F14); it auto-resolves indices from the unified tech (finding F9).
+- `filterwarnings = ["error::DeprecationWarning:gds_fdtd.*"]` in `pyproject.toml` turns any in-package `DeprecationWarning` into a test error — the only remaining source is the `Component` nested-list shim.
+- Materials in a unified tech carry hints for *every* engine; a missing optional engine (e.g. tidy3d not installed) must not break loading for the others (finding F13) — keep it that way.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The version is derived **from git tags** via `hatch-vcs` — there is nothing to
 version string in the source. To release:
 
 ```bash
-git tag v0.5.0
+git tag v0.6.0
 git push --tags
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,17 +5,27 @@ should be able to read this, understand the current state, and pick up work
 without losing context. Keep it current; move granular tracking to GitHub
 Issues under the `v0.5.1` milestone as items are picked up.
 
-## Where we are — v0.5.0 (released 2026-07-09)
+## Where we are — v0.6.0 (breaking legacy cleanup; on `main`, not yet tagged)
 
 Solver-agnostic FDTD: one `Component` + one technology file + one
 `SimulationSpec`, any engine (tidy3d / Lumerical / beamz) behind
 `get_solver(name)(component, tech, spec)`. Three-engine agreement within
 0.052 dB on identical jobs (tidy3d↔Lumerical within 0.0033 dB), recorded and
-asserted every PR. Honest branch coverage 81% (full package). Docs on GitHub
-Pages. OpenSSF Scorecard 7.0.
+asserted every PR. Branch coverage ~82.7% (all-extras leg; base floor 75).
+Docs on GitHub Pages. OpenSSF Scorecard 7.0 (branch protection now enabled).
 
-The modernization arc (Phases 0–7, ~80 commits) is complete and shipped; its
-plan has been retired. Deferred items from that arc are captured in the
+**0.6.0 (breaking) — landed on `main` (PRs #27–#32), not yet tagged.** The
+staged legacy cleanup removed the entire pre-0.5 public surface: the
+`gds_fdtd.solver` / `solver_tidy3d` / `solver_lumerical` modules, the
+`core.technology` class + `core.parse_yaml_tech` + the whole `gds_fdtd.core`
+shim module, the `Technology.to_legacy_dict()` name (→ `to_solver_dict()`), and
+the public `gds_fdtd.sparams` module (→ internal `_sparams`). The supported API
+is `get_solver(name)` + `Technology` + `SimulationSpec` + `SMatrix`. See
+[`HANDOFF.md`](HANDOFF.md) for the full development arc and the live-validation
+runbook (tidy3d/Lumerical) — which has NOT been re-run since the cleanup.
+
+The modernization arc (Phases 0–7, ~80 commits) that produced 0.5.0 is complete
+and shipped; its plan has been retired. Deferred items are captured in the
 [Carry-forward backlog](#carry-forward-backlog) below.
 
 ## Guiding principles (non-negotiable)
@@ -93,7 +103,7 @@ The released 0.5.0 is clean at the surface; the depth to attack is the
 
 - **Flatten the legacy wrap:** ✅ DONE (0.6.0). `solver_lumerical.py`
   (pure duplicate) and `solver_tidy3d.py` (deprecated alias) were removed;
-  the base `solver.py` moved to the internal `solvers/_engine_base.py` and
+  the base `solver.py` moved to the internal `solvers/_tidy3d_base.py` and
   the public `gds_fdtd.solver` module was removed. The Tidy3D scene-building
   engine is now internal (`solvers/_tidy3d_engine`), and the supported
   surface is `solvers/` (`get_solver` + the adapters) only. ~1050 lines of
@@ -126,7 +136,7 @@ CRITICAL/HIGH move the needle most.
 
 | Check | Now | Weight | Action | Who |
 |---|---|---|---|---|
-| **Branch-Protection** | 0 | HIGH | Protect `main`: require PR + passing `pass`/CodeQL checks, up-to-date branches, ≥1 review, dismiss stale approvals, linear history, block force-push, enforce for admins, require conversation resolution. | owner (admin API/settings) |
+| **Branch-Protection** | ✅ | HIGH | DONE — `main` requires a PR + the passing `pass` check + up-to-date branches + linear history; force-pushes blocked; enforced for admins. Solo-friendly: 0 required reviews (raising this needs a second maintainer / review bot). | owner ✅ |
 | **Code-Review** | 0 | HIGH | Route *all* changes through PRs (principle 5) and get an approving review before merge. Solo dev is the ceiling here — a second reviewer/maintainer or a review bot is the only way to fully satisfy it. | owner + process |
 | **Signed-Releases** | 0 | HIGH | Sigstore-sign release artifacts in `release.yml`; attach signatures to the GitHub Release. (PyPI already gets PEP 740 attestations via trusted publishing.) | executor (workflow) |
 | **Fuzzing** | 0 | MEDIUM | atheris fuzz targets on the technology-YAML and `.dat` parsers, run directly in CI (import atheris is the Scorecard signal). | executor |
@@ -189,8 +199,8 @@ Deferred with documented rationale; resume when the blocker clears.
 
 Tracked here so they don't get lost; none block executor work.
 
-- [ ] **Branch protection on `main`** (WS5) — the single biggest Scorecard
-      lever.
+- [x] **Branch protection on `main`** (WS5) — ✅ enabled: PR + green `pass` +
+      up-to-date + linear history required, force-pushes blocked, admins enforced.
 - [ ] **PyPI trusted publisher** (project `gds_fdtd`, owner `SiEPIC`,
       workflow `release.yml`, env `pypi`) — in progress with Lukas; then
       re-run the release build's publish job. Unlocks Packaging (WS5).

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -55,9 +55,11 @@ Solver layer
     group (see :doc:`adding_a_solver`).
 
 ``solvers.tidy3d`` / ``solvers.lumerical`` / ``solvers.beamz``
-    The engine adapters. The tidy3d and Lumerical adapters wrap the
-    pre-0.5 implementation modules (``solver_tidy3d`` / ``solver_lumerical``,
-    deprecated as public API, removal at v1.0).
+    The engine adapters. The tidy3d adapter drives an internal scene builder
+    (``solvers/_tidy3d_base`` + ``solvers/_tidy3d_engine``); the Lumerical
+    adapter generates ``.lsf`` directly; beamz builds a JAX FDTD grid. The
+    pre-0.5 ``solver_tidy3d`` / ``solver_lumerical`` modules were removed in
+    0.6.0.
 
 ``grid`` / ``modes`` / ``extraction``
     The kernel-engine pipeline: permittivity rasterization with sub-pixel

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,10 +4,10 @@
 Welcome to gds_fdtd's documentation!
 =====================================
 
-``gds_fdtd`` is a Python package that helps you set up FDTD simulations for photonic devices. It works with both Tidy3D and Lumerical solvers.
+``gds_fdtd`` is a Python package that helps you set up FDTD simulations for photonic devices. One component + one technology file + one ``SimulationSpec`` runs on any engine — tidy3d (cloud), Lumerical (local), or beamz (free/JAX) — behind a single ``get_solver(name)`` contract.
 
 What you can do with it:
-- Run simulations using either Tidy3D or Lumerical
+- Run simulations on tidy3d, Lumerical, or beamz via ``get_solver(name)``
 - Handle TE and TM polarizations in the same simulation
 - Extract and analyze S-parameters from your results
 - Monitor electromagnetic fields during simulation

--- a/docs/sparameters.rst
+++ b/docs/sparameters.rst
@@ -1,492 +1,155 @@
 Working with S-Parameters
 =========================
 
-S-parameters (scattering parameters) are used to characterize how photonic components work. The ``gds_fdtd`` package has tools for calculating, analyzing, and exporting S-parameters from FDTD simulations.
+S-parameters (scattering parameters) characterize how a photonic component
+routes optical power between its ports. In ``gds_fdtd`` every solver returns
+one canonical container — :class:`gds_fdtd.smatrix.SMatrix` — regardless of the
+engine, so the analysis below is identical for tidy3d, Lumerical, and beamz.
 
 S-Parameter Fundamentals
 ------------------------
 
-S-parameters describe how electromagnetic waves are scattered by a multi-port network. For a photonic device:
+S-parameters describe how waves scatter through a multi-port network:
 
-- **S₁₁**: Reflection at port 1 when excited at port 1
-- **S₂₁**: Transmission from port 1 to port 2
-- **S₁₂**: Transmission from port 2 to port 1
-- **S₂₂**: Reflection at port 2 when excited at port 2
+- **S₁₁**: reflection at port 1 when excited at port 1
+- **S₂₁**: transmission from port 1 to port 2
+- **S₁₂**: transmission from port 2 to port 1
+- **S₂₂**: reflection at port 2 when excited at port 2
 
-For multi-modal devices, S-parameters include mode indices:
-- **S₁₁⁽ᵀᴱ→ᵀᴱ⁾**: TE mode reflection at port 1
-- **S₂₁⁽ᵀᴱ→ᵀᴹ⁾**: TE to TM mode conversion from port 1 to port 2
+For multi-modal devices each path also carries mode indices (mode 1 = TE-like,
+mode 2 = TM-like), e.g. **S₂₁⁽ᵀᴱ→ᵀᴹ⁾** is TE→TM conversion from port 1 to 2.
+See :doc:`multimodal` for the multi-mode workflow.
 
-Accessing S-Parameters
-----------------------
+Getting the S-matrix
+--------------------
 
-After running a simulation, S-parameters are available through the solver's ``sparameters`` property:
-
-Basic Access
-^^^^^^^^^^^^
+``run()`` is the only method that spends money/licenses/compute; it returns an
+``SMatrix``. Nothing is stored on the solver — hold onto the returned object:
 
 .. code-block:: python
 
-    # Run simulation first
-    solver.run()
+    from gds_fdtd.solvers import get_solver
+    from gds_fdtd.spec import SimulationSpec
 
-    # Access S-parameters object
-    sparams = solver.sparameters
+    solver = get_solver("tidy3d")(component, technology=tech, spec=SimulationSpec())
+    smatrix = solver.run()          # -> gds_fdtd.smatrix.SMatrix
 
-    # Basic information
-    print(f"Component: {sparams.name}")
-    print(f"Number of S-parameter entries: {len(sparams.data)}")
-    print(f"Frequency points: {len(sparams.wavelength)}")
+    print(f"Component:       {smatrix.name}")
+    print(f"Ports:           {smatrix.n_ports} {smatrix.port_names}")
+    print(f"Modes:           {smatrix.n_modes}")
+    print(f"Frequency pts:   {smatrix.f.size}")
 
-Wavelength Information
-^^^^^^^^^^^^^^^^^^^^^^
-
-.. code-block:: python
-
-    # Get wavelength array
-    wavelengths = solver.sparameters.wavelength  # in micrometers
-    frequencies = solver.sparameters.frequency   # in Hz
-
-    print(f"Wavelength range: {wavelengths[0]:.3f} - {wavelengths[-1]:.3f} μm")
-    print(f"Number of points: {len(wavelengths)}")
-
-Individual S-Parameter Access
+Wavelength / frequency grids
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Access specific S-parameters using the ``S()`` method:
-
 .. code-block:: python
 
-    # Single-mode device
-    s21 = solver.sparameters.S(in_port=1, out_port=2, in_modeid=1, out_modeid=1)
+    wavelengths_um = smatrix.wavelength_um   # micrometers (descending as f ascends)
+    frequencies_hz = smatrix.f               # Hz, ascending
 
-    # Multi-modal device - different mode combinations
-    s21_te_te = solver.sparameters.S(in_port=1, out_port=2, in_modeid=1, out_modeid=1)  # TE→TE
-    s21_te_tm = solver.sparameters.S(in_port=1, out_port=2, in_modeid=1, out_modeid=2)  # TE→TM
-    s21_tm_te = solver.sparameters.S(in_port=1, out_port=2, in_modeid=2, out_modeid=1)  # TM→TE
-    s21_tm_tm = solver.sparameters.S(in_port=1, out_port=2, in_modeid=2, out_modeid=2)  # TM→TM
+    print(f"Wavelength range: {wavelengths_um.min():.3f} - {wavelengths_um.max():.3f} um")
 
-S-Parameter Properties
-^^^^^^^^^^^^^^^^^^^^^^
-
-Each S-parameter entry contains magnitude and phase information:
-
-.. code-block:: python
-
-    # Get specific S-parameter
-    s21 = solver.sparameters.S(in_port=1, out_port=2, in_modeid=1, out_modeid=1)
-
-    # Access properties
-    magnitude = s21.s_mag      # Linear magnitude
-    phase = s21.s_phase        # Phase in radians
-    power = [abs(m)**2 for m in magnitude]  # Power transmission
-
-    # Convert to dB
-    import numpy as np
-    transmission_db = 10 * np.log10(power)
-
-    print(f"Peak transmission: {max(power):.4f} ({max(transmission_db):.2f} dB)")
-
-Visualization and Analysis
+Accessing individual paths
 --------------------------
 
-Built-in Plotting
-^^^^^^^^^^^^^^^^^
-
-The package provides automatic plotting of all S-parameters:
-
-.. code-block:: python
-
-    # Plot all S-parameters
-    plot_smatrix(smatrix, kind="db")  # from gds_fdtd.plotting
-
-    # Or directly plot S-parameters
-    solver.sparameters.plot()
-
-Custom Plotting
-^^^^^^^^^^^^^^^
-
-Create custom plots for specific analysis:
-
-.. code-block:: python
-
-    import matplotlib.pyplot as plt
-    import numpy as np
-
-    # Get wavelength and S-parameters
-    wavelengths = solver.sparameters.wavelength
-    s21 = solver.sparameters.S(in_port=1, out_port=2, in_modeid=1, out_modeid=1)
-    s31 = solver.sparameters.S(in_port=1, out_port=3, in_modeid=1, out_modeid=1)
-
-    # Transmission plot
-    fig, ax = plt.subplots(figsize=(10, 6))
-    ax.plot(wavelengths, 10*np.log10([abs(m)**2 for m in s21.s_mag]),
-            label='Port 1→2', linewidth=2)
-    ax.plot(wavelengths, 10*np.log10([abs(m)**2 for m in s31.s_mag]),
-            label='Port 1→3', linewidth=2)
-
-    ax.set_xlabel('Wavelength (μm)')
-    ax.set_ylabel('Transmission (dB)')
-    ax.set_title('Device Transmission Spectrum')
-    ax.grid(True, alpha=0.3)
-    ax.legend()
-    plt.show()
-
-Multi-Modal Analysis
-^^^^^^^^^^^^^^^^^^^^
-
-Analyze mode conversion and polarization effects:
-
-.. code-block:: python
-
-    # Multi-modal transmission analysis
-    wavelengths = solver.sparameters.wavelength
-
-    # Get all mode combinations for port 1→4
-    s41_te_te = solver.sparameters.S(in_port=1, out_port=4, in_modeid=1, out_modeid=1)
-    s41_te_tm = solver.sparameters.S(in_port=1, out_port=4, in_modeid=1, out_modeid=2)
-    s41_tm_te = solver.sparameters.S(in_port=1, out_port=4, in_modeid=2, out_modeid=1)
-    s41_tm_tm = solver.sparameters.S(in_port=1, out_port=4, in_modeid=2, out_modeid=2)
-
-    # Plot multi-modal transmission
-    fig, ax = plt.subplots(figsize=(12, 8))
-    ax.plot(wavelengths, 10*np.log10([abs(m)**2 for m in s41_te_te.s_mag]),
-            label='TE→TE', linewidth=2)
-    ax.plot(wavelengths, 10*np.log10([abs(m)**2 for m in s41_tm_tm.s_mag]),
-            label='TM→TM', linewidth=2)
-    ax.plot(wavelengths, 10*np.log10([abs(m)**2 for m in s41_te_tm.s_mag]),
-            label='TE→TM (conversion)', linewidth=2, linestyle='--')
-    ax.plot(wavelengths, 10*np.log10([abs(m)**2 for m in s41_tm_te.s_mag]),
-            label='TM→TE (conversion)', linewidth=2, linestyle='--')
-
-    ax.set_xlabel('Wavelength (μm)')
-    ax.set_ylabel('Transmission (dB)')
-    ax.set_title('Multi-Modal S-Parameters: Port 1 → Port 4')
-    ax.grid(True, alpha=0.3)
-    ax.legend()
-    plt.show()
-
-Performance Metrics
-^^^^^^^^^^^^^^^^^^^
-
-Calculate common device performance metrics:
+Ports are addressed by name (``"opt1"``) or by their trailing-digit id
+(``1``); modes are 1-based. ``sel`` returns the complex response; ``magnitude_db``
+returns ``|S|²`` in dB. Both are ``(F,)`` arrays over the wavelength grid.
 
 .. code-block:: python
 
     import numpy as np
 
-    def calculate_metrics(solver, in_port=1, out_port=2):
-        """Calculate common performance metrics."""
-        wavelengths = solver.sparameters.wavelength
+    # complex transmission port1 -> port2 (fundamental mode)
+    s21 = smatrix.sel(out="opt2", in_="opt1", mode_out=1, mode_in=1)
 
-        # Get S-parameters
-        s_trans = solver.sparameters.S(in_port=in_port, out_port=out_port,
-                                      in_modeid=1, out_modeid=1)
-        s_refl = solver.sparameters.S(in_port=in_port, out_port=in_port,
-                                     in_modeid=1, out_modeid=1)
+    # the same path in dB (|S|^2)
+    s21_db = smatrix.magnitude_db(out="opt2", in_="opt1")   # modes default to 1
 
-        # Calculate metrics
-        transmission = [abs(m)**2 for m in s_trans.s_mag]
-        reflection = [abs(m)**2 for m in s_refl.s_mag]
-        insertion_loss = [-10*np.log10(t) for t in transmission]
-        return_loss = [-10*np.log10(r) for r in reflection]
+    # reflection at port 1
+    s11_db = smatrix.magnitude_db(out="opt1", in_="opt1")
 
-        # Find performance at specific wavelength
-        target_wl = 1.55  # μm
-        idx = np.argmin(np.abs(wavelengths - target_wl))
+    print(f"Peak transmission: {s21_db.max():.2f} dB")
+    print(f"Peak reflection:   {s11_db.max():.2f} dB")
 
-        print(f"Performance at {target_wl} μm:")
-        print(f"  Transmission: {transmission[idx]:.4f} ({-insertion_loss[idx]:.2f} dB)")
-        print(f"  Reflection: {reflection[idx]:.4f} ({-return_loss[idx]:.2f} dB)")
-        print(f"  Insertion Loss: {insertion_loss[idx]:.2f} dB")
-        print(f"  Return Loss: {return_loss[idx]:.2f} dB")
+Unmeasured paths (partial matrices) are ``NaN`` — a device simulated with only
+port 1 excited leaves the port-2-excited columns ``NaN``, which the accessors,
+physics checks, and exporters all handle.
 
-        return {
-            'wavelength': wavelengths,
-            'transmission': transmission,
-            'reflection': reflection,
-            'insertion_loss': insertion_loss,
-            'return_loss': return_loss
-        }
-
-    # Calculate metrics
-    metrics = calculate_metrics(solver, in_port=1, out_port=4)
-
-Exporting S-Parameters
-----------------------
-
-.dat File Export
-^^^^^^^^^^^^^^^^
-
-Export S-parameters to standard .dat format for use in circuit simulators:
-
-.. code-block:: python
-
-    # Export to INTERCONNECT
-    smatrix.to_dat("my_device.dat")
-
-    # Manual export
-    smatrix.to_dat("my_device_sparams.dat")
-
-    # Custom filepath
-    import os
-    dat_path = os.path.join(solver.working_dir, "custom_sparams.dat")
-    smatrix.to_dat(dat_path)
-
-The .dat file format is compatible with most circuit simulators and contains:
-- Frequency sweep information
-- S-parameter magnitude and phase data
-- Multi-port and multi-modal data
-
-Custom Export Formats
-^^^^^^^^^^^^^^^^^^^^^^
-
-Export to custom formats for specific analysis tools:
-
-.. code-block:: python
-
-    import json
-    import numpy as np
-
-    def export_json(solver, filename):
-        """Export S-parameters to JSON format."""
-        data = {
-            'component': solver.component.name,
-            'wavelength_um': solver.sparameters.wavelength.tolist(),
-            'frequency_hz': solver.sparameters.frequency.tolist(),
-            'sparameters': []
-        }
-
-        for sparam in solver.sparameters.data:
-            entry = {
-                'in_port': sparam.in_port,
-                'out_port': sparam.out_port,
-                'in_mode': sparam.in_modeid,
-                'out_mode': sparam.out_modeid,
-                'magnitude': sparam.s_mag,
-                'phase_rad': sparam.s_phase,
-                'power': [abs(m)**2 for m in sparam.s_mag]
-            }
-            data['sparameters'].append(entry)
-
-        with open(filename, 'w') as f:
-            json.dump(data, f, indent=2)
-
-        print(f"S-parameters exported to {filename}")
-
-    # Export to JSON
-    export_json(solver, "device_sparams.json")
-
-Touchstone Format
-^^^^^^^^^^^^^^^^^
-
-Export to Touchstone (.s2p, .s4p) format for RF/microwave tools:
-
-.. code-block:: python
-
-    def export_touchstone(solver, filename):
-        """Export to Touchstone format."""
-        import numpy as np
-
-        # Get number of ports
-        n_ports = len(solver.fdtd_ports)
-        wavelengths = solver.sparameters.wavelength
-        frequencies = solver.sparameters.frequency
-
-        with open(filename, 'w') as f:
-            # Header
-            f.write(f"# Hz S MA R 50\n")
-            f.write(f"! Exported from gds_fdtd for {solver.component.name}\n")
-
-            # Data for each frequency
-            for i, freq in enumerate(frequencies):
-                f.write(f"{freq:.6e}")
-
-                # Write S-parameters in order (S11, S12, S21, S22 for 2-port)
-                for out_port in range(1, n_ports + 1):
-                    for in_port in range(1, n_ports + 1):
-                        s_param = solver.sparameters.S(in_port=in_port, out_port=out_port,
-                                                      in_modeid=1, out_modeid=1)
-                        mag = abs(s_param.s_mag[i])
-                        phase_deg = np.degrees(s_param.s_phase[i])
-                        f.write(f" {mag:.6e} {phase_deg:.6e}")
-
-                f.write("\n")
-
-        print(f"Touchstone file exported: {filename}")
-
-    # Export 4-port device
-    export_touchstone(solver, "device.s4p")
-
-S-Parameter Validation
-----------------------
-
-Data Quality Checks
-^^^^^^^^^^^^^^^^^^^^
-
-Validate S-parameter data quality and physical consistency:
-
-.. code-block:: python
-
-    def validate_sparameters(solver):
-        """Validate S-parameter data for physical consistency."""
-        print("S-Parameter Validation:")
-        print("=" * 40)
-
-        # Check data completeness
-        expected_combinations = len(solver.fdtd_ports)**2 * len(solver.modes)**2
-        actual_combinations = len(solver.sparameters.data)
-        print(f"S-parameter combinations: {actual_combinations}/{expected_combinations}")
-
-        # Check energy conservation (for lossless devices)
-        wavelengths = solver.sparameters.wavelength
-        n_ports = len(solver.fdtd_ports)
-
-        for i, wl in enumerate(wavelengths[::10]):  # Check every 10th point
-            total_power = 0
-            for out_port in range(1, n_ports + 1):
-                s_param = solver.sparameters.S(in_port=1, out_port=out_port,
-                                              in_modeid=1, out_modeid=1)
-                power = abs(s_param.s_mag[i*10])**2
-                total_power += power
-
-            print(f"λ={wl:.3f}μm: Total power = {total_power:.4f}")
-            if total_power > 1.01:
-                print(f"  WARNING: Power > 1 (gain or numerical error)")
-            elif total_power < 0.95:
-                print(f"  INFO: Power < 1 (loss present)")
-
-    # Run validation
-    validate_sparameters(solver)
-
-Reciprocity Check
-^^^^^^^^^^^^^^^^^
-
-For reciprocal devices, verify S₁₂ = S₂₁:
-
-.. code-block:: python
-
-    def check_reciprocity(solver, tolerance=0.01):
-        """Check device reciprocity."""
-        n_ports = len(solver.fdtd_ports)
-        wavelengths = solver.sparameters.wavelength
-
-        print("Reciprocity Check:")
-        print("-" * 20)
-
-        for i in range(1, n_ports + 1):
-            for j in range(i + 1, n_ports + 1):
-                s_ij = solver.sparameters.S(in_port=i, out_port=j, in_modeid=1, out_modeid=1)
-                s_ji = solver.sparameters.S(in_port=j, out_port=i, in_modeid=1, out_modeid=1)
-
-                # Compare magnitudes
-                mag_diff = np.mean([abs(abs(m1) - abs(m2)) for m1, m2 in
-                                   zip(s_ij.s_mag, s_ji.s_mag)])
-
-                print(f"S{i}{j} vs S{j}{i}: Avg magnitude difference = {mag_diff:.4f}")
-                if mag_diff > tolerance:
-                    print(f"  WARNING: Large reciprocity error (>{tolerance})")
-
-    # Check reciprocity
-    check_reciprocity(solver)
-
-More S-Parameter Analysis
------------------------------
-
-Frequency Domain Analysis
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Analyze S-parameters in the frequency domain:
-
-.. code-block:: python
-
-    def analyze_bandwidth(solver, in_port=1, out_port=2, threshold_db=-3):
-        """Calculate 3dB bandwidth."""
-        s_param = solver.sparameters.S(in_port=in_port, out_port=out_port,
-                                      in_modeid=1, out_modeid=1)
-        wavelengths = solver.sparameters.wavelength
-
-        # Convert to dB
-        power_db = [10*np.log10(abs(m)**2) for m in s_param.s_mag]
-        max_power_db = max(power_db)
-        threshold = max_power_db + threshold_db  # -3dB from peak
-
-        # Find bandwidth
-        above_threshold = [p > threshold for p in power_db]
-        if any(above_threshold):
-            start_idx = above_threshold.index(True)
-            end_idx = len(above_threshold) - above_threshold[::-1].index(True) - 1
-
-            bandwidth = wavelengths[end_idx] - wavelengths[start_idx]
-            center_wl = (wavelengths[start_idx] + wavelengths[end_idx]) / 2
-
-            print(f"Device Bandwidth Analysis:")
-            print(f"  Center wavelength: {center_wl:.3f} μm")
-            print(f"  {-threshold_db}dB bandwidth: {bandwidth:.3f} μm")
-            print(f"  Relative bandwidth: {bandwidth/center_wl*100:.2f}%")
-
-            return center_wl, bandwidth
-        else:
-            print("No points above threshold found")
-            return None, None
-
-    # Analyze bandwidth
-    center, bw = analyze_bandwidth(solver, threshold_db=-3)
-
-Group Delay Analysis
-^^^^^^^^^^^^^^^^^^^^
-
-Calculate group delay from S-parameter phase:
-
-.. code-block:: python
-
-    def calculate_group_delay(solver, in_port=1, out_port=2):
-        """Calculate group delay from S-parameter phase."""
-        s_param = solver.sparameters.S(in_port=in_port, out_port=out_port,
-                                      in_modeid=1, out_modeid=1)
-
-        frequencies = solver.sparameters.frequency
-        phases = s_param.s_phase
-
-        # Unwrap phase for continuous derivative
-        phases_unwrapped = np.unwrap(phases)
-
-        # Calculate group delay: τ = -dφ/dω
-        group_delay = -np.gradient(phases_unwrapped, frequencies)
-        wavelengths = solver.sparameters.wavelength
-
-        # Plot group delay
-        fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 8))
-
-        # Phase plot
-        ax1.plot(wavelengths, np.degrees(phases), 'b-', linewidth=2)
-        ax1.set_ylabel('Phase (degrees)')
-        ax1.set_title('S-Parameter Phase and Group Delay')
-        ax1.grid(True, alpha=0.3)
-
-        # Group delay plot
-        ax2.plot(wavelengths, group_delay * 1e12, 'r-', linewidth=2)  # Convert to ps
-        ax2.set_xlabel('Wavelength (μm)')
-        ax2.set_ylabel('Group Delay (ps)')
-        ax2.grid(True, alpha=0.3)
-
-        plt.tight_layout()
-        plt.show()
-
-        return group_delay
-
-    # Calculate group delay
-    gd = calculate_group_delay(solver)
-
-Best Practices
+Physics checks
 --------------
 
-1. **Always validate S-parameter data** for physical consistency
-2. **Use appropriate wavelength resolution** for your analysis needs
-3. **Check reciprocity** for passive, reciprocal devices
-4. **Export data in multiple formats** for different analysis tools
-5. **Document simulation parameters** with S-parameter files
-6. **Verify convergence** with mesh and time step refinement
-7. **Use multi-modal analysis** for polarization-sensitive devices
+The checks operate on the full (port, mode)-flattened matrix and are NaN-aware
+(only mutually measured pairs count):
 
-These S-parameter tools let you analyze photonic devices for research or commercial use.
+.. code-block:: python
+
+    smatrix.is_reciprocal()          # S == S^T within tolerance
+    smatrix.is_passive()             # no excitation outputs more power than it received
+    balance = smatrix.power_balance()  # sum_out |S|^2 per (freq, in-port*mode) excitation
+
+For a lossless, reciprocal device ``power_balance()`` sits near 1.0 and both
+predicates return ``True`` (within ``atol``).
+
+Plotting
+--------
+
+``plot_smatrix`` plots every measured path versus wavelength (paths whose peak
+is below −60 dB are hidden so large matrices stay readable):
+
+.. code-block:: python
+
+    from gds_fdtd.plotting import plot_smatrix
+
+    fig, ax = plot_smatrix(smatrix, kind="db")     # kind: "db" | "linear" | "phase"
+    fig.savefig("device_sparams.png", dpi=150, bbox_inches="tight")
+
+    # restrict to specific (out, in, mode_out, mode_in) paths:
+    paths = [("opt2", "opt1", 1, 1), ("opt1", "opt1", 1, 1)]
+    plot_smatrix(smatrix, kind="db", paths=paths)
+
+Exporting
+---------
+
+``SMatrix`` writes the standard interchange formats directly — no hand-rolled
+writers needed:
+
+.. code-block:: python
+
+    smatrix.to_dat("device.dat")          # Lumerical INTERCONNECT (partial matrices OK)
+    smatrix.to_touchstone("device.s2p")   # Touchstone v1 (.sNp; N = n_ports*n_modes)
+    smatrix.to_hdf5("device.h5")          # requires h5py
+    smatrix.to_npz("device.npz")          # numpy built-in, always available
+
+    # round-trips back to an SMatrix:
+    from gds_fdtd.smatrix import SMatrix
+    again = SMatrix.from_dat("device.dat")
+
+Notes:
+
+- ``.dat`` and ``.npz``/``.h5`` preserve NaN (unmeasured) paths; Touchstone
+  requires a complete matrix and raises on NaN — export ``.dat`` for partial
+  matrices.
+- Touchstone flattens ``(port, mode)`` pairs port-major; the ordering is written
+  into the file header.
+- ``.dat`` is round-trip lossless (``to_dat`` → ``from_dat``); the INTERCONNECT
+  reader/writer is an internal helper (``gds_fdtd._sparams``) — use the
+  ``SMatrix`` methods above rather than importing it.
+
+Working offline with recorded results
+--------------------------------------
+
+You do not need an engine to exercise the S-matrix API — ``examples/09_smatrix``
+loads a recorded real result and demonstrates the I/O, physics checks, and
+plotting entirely offline:
+
+.. code-block:: python
+
+    from gds_fdtd.smatrix import SMatrix
+
+    sm = SMatrix.from_dat("examples/09_smatrix/si_sin_escalator.dat")
+    print(sm.is_reciprocal(), sm.is_passive())
+    plot_smatrix(sm, kind="db")
+
+See also :doc:`multimodal` (multi-mode / polarization) and :doc:`simulations`
+(the end-to-end GDS → S-parameters flow).

--- a/docs/technology.rst
+++ b/docs/technology.rst
@@ -441,7 +441,7 @@ Validate technology definitions:
         if hasattr(tech, 'device') and tech.device:
             print(f"Device layers: {len(tech.device)}")
             for i, layer in enumerate(tech.device):
-                print(f"  Layer {i}: GDS {layer['layer']} at z={layer['z_base']}μm")
+                print(f"  Layer {i}: GDS {layer.layer} at z={layer.z_base}μm")
 
         print()
 
@@ -458,15 +458,9 @@ Debug material and layer issues:
         print("-" * 20)
 
         for structure in component.structures:
-            if isinstance(structure, list):
-                for s in structure:
-                    print(f"Structure {s.name}:")
-                    print(f"  Material: {s.material}")
-                    print(f"  Layer: {s.layer}")
-            else:
-                print(f"Structure {structure.name}:")
-                print(f"  Material: {structure.material}")
-                print(f"  Layer: {structure.layer}")
+            print(f"Structure {structure.name} (role={structure.role}):")
+            print(f"  Material: {structure.material}")
+            print(f"  Layer: {structure.layer}")
 
 Creating Technology Files
 -------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ filterwarnings = [
 [tool.codespell]
 # TE/TM = transverse electric/magnetic (photonics); OD/TE show up in SVG path data
 ignore-words-list = "TE,te,TETM,tetm,subtrate,Subtrate"  # Subtrate: intentional legacy-typo tolerance in _is_background
-skip = "*.svg,*.gds,*.lock,*.ipynb,docs/_build,docs/_autosummary,MODERNIZATION_PLAN.md"
+skip = "*.svg,*.gds,*.lock,*.ipynb,docs/_build,docs/_autosummary"
 
 [tool.ruff]
 line-length = 100
@@ -140,7 +140,7 @@ extend-exclude = ["examples"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B", "A", "C4"]
-# Temporary ignores — each is scheduled for a proper fix in MODERNIZATION_PLAN.md.
+# Temporary ignores — tracked in ROADMAP.md; remove each in its owning cleanup.
 # Do NOT silently fix these in unrelated PRs; remove each ignore in its owning WP.
 ignore = [
   "E501",  # long comments/strings; wrapped progressively as files are touched in Phase 1/2

--- a/tests/conformance/test_solver_contract.py
+++ b/tests/conformance/test_solver_contract.py
@@ -4,7 +4,7 @@ Every adapter registered in gds_fdtd.solvers must pass these tests. They run
 against FakeSolver today; as WP3.1c/d land, the ported adapters join the
 `all_solver_classes` list automatically via the registry.
 
-Contract highlights (Part 4 of MODERNIZATION_PLAN.md):
+Contract highlights (from the 0.5 solver-contract design):
 - constructor is cheap and PURE: no files created, no sockets;
 - validate() returns list[str];
 - build() is offline, deterministic, and returns SetupArtifacts;

--- a/tests/test_examples_importable.py
+++ b/tests/test_examples_importable.py
@@ -1,5 +1,5 @@
 """
-Examples import check — WP0.4 of MODERNIZATION_PLAN.md.
+Examples import check (WP0.4 of the 0.5 modernization arc).
 
 For every examples/**/*.py, parse the AST (never execute) and assert that every
 `gds_fdtd` symbol it imports actually exists in the installed package. This makes

--- a/tests/test_golden.py
+++ b/tests/test_golden.py
@@ -1,5 +1,5 @@
 """
-Golden (characterization) tests — WP0.3 of MODERNIZATION_PLAN.md.
+Golden (characterization) tests (WP0.3 of the 0.5 modernization arc).
 
 These pin the CURRENT geometry-building behavior of load_component_from_tech
 (bugs and all) so that the Phase 1/2 refactors can prove geometric equivalence.

--- a/tests/test_lyprocessor.py
+++ b/tests/test_lyprocessor.py
@@ -8,8 +8,8 @@ every test collected after it (the golden tests received a fake simprocessor) â€
 that exec-compiled `pass` statements at every line of the module under test,
 faking 100% coverage. All three are gone. Module fakes are now scoped with
 monkeypatch inside the tests that need them. Real KLayout-backed tests for
-load_cell/load_region/load_structure/load_ports arrive with the Phase 1 bug-fix
-WPs (see MODERNIZATION_PLAN.md).
+load_cell/load_region/load_structure/load_ports were added in the 0.5
+modernization arc (git history).
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Brings all documentation in line with the 0.6.0 legacy cleanup (PRs #28–#32, now on `main`) and adds a **handoff document** for the next step: live validation on a machine with tidy3d + Lumerical.

## Highlights
- **`HANDOFF.md` (new)** — the full 0.1→0.6 development arc, the current architecture map, an honest *validated-offline vs NOT-run-here* section, and an ordered **live-validation runbook** (examples end-to-end in a fresh interpreter, `scripts/cloud_smoke.py`, Lumerical, regenerate the three-engine `tests/recorded/*.npz`, refresh `SOLVER_STATUS.md`) + guardrails and gotchas.
- **`docs/sparameters.rst` rewritten** around the `SMatrix` API — the old 493-line page was built on the removed `solver.sparameters` / `.fdtd_ports` / `.working_dir` / `.S()`/`.data` surface; every code block would have raised `AttributeError`.
- **`ROADMAP.md`** — "Where we are" now reflects 0.6.0 (breaking cleanup landed, not yet tagged); fixed `_engine_base.py`→`_tidy3d_base.py`; branch-protection marked done (WS5 table + owner box); links to `HANDOFF.md`.
- **`AGENTS.md`** — retired `MODERNIZATION_PLAN.md` → `ROADMAP.md`/`HANDOFF.md`; F10 pointer → CHANGELOG.
- **`docs/architecture.rst`** — `solver_tidy3d`/`solver_lumerical` now described as removed in 0.6 (were "deprecated, removal at v1.0"). **`docs/index.rst`** — adds beamz + the `get_solver` registry.
- **`docs/technology.rst`** — fixes a `DeviceLayer` subscript (`TypeError`) and drops a deprecated nested-structures pattern.
- `CONTRIBUTING.md` branch-protection box checked; `README` release-tag example → `v0.6.0`; `pyproject` + 4 test docstrings drop the retired `MODERNIZATION_PLAN.md` references.

Deliberately deferred (noted in HANDOFF §8): expanding the `docs/modules.rst` API autosummary needs a module-docstring RST-hygiene pass first, so it's left minimal to keep the docs build warning-free.

## Verification
sphinx docs build clean (no warnings); full offline suite green (**283 passed**); `ruff` + `ruff format` + `codespell` + full `prek` clean. No source-logic files touched (docs + config + test docstrings only).