### PR TITLE
docs: 0.6.0 changelog entry + roadmap refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — targeting 0.6.0 (breaking)
+## [0.6.0] - 2026-07-15 (breaking)
 
 ### Removed (BREAKING)
 - The pre-0.5 solver classes and their modules were removed:
@@ -75,6 +75,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parsers (`fuzz/`), run directly on PRs that touch the library.
 - Release artifacts are now Sigstore-signed (keyless, GitHub OIDC); the
   `.sigstore` bundles are attached to each GitHub Release.
+- **Executed-notebook examples curriculum** (`00_quickstart` …
+  `10b_polarization`, 13 notebooks): jupytext-paired `.py` sources committed
+  alongside executed `.ipynb` with real solver outputs. Includes the
+  three-engine y-branch comparison, the sharp-S-bend convergence study
+  (converged ≠ correct), the frontend × engine matrix (gdsfactory / SiEPIC /
+  raw GDS on beamz / tidy3d / Lumerical), and polarization devices (a
+  directional-coupler PBS and gdsfactory's splitter-rotator, TE0+TM0 on two
+  engines, with the symmetric-cladding negative control). Recorded artifacts
+  ship with PROVENANCE notes so every notebook reproduces for free.
+- **Visualization toolkit** (`gds_fdtd.plotting`): `plot_component` (geometry +
+  auto-detected ports + FDTD region), `plot_tech_stack`, `plot_permittivity`,
+  `plot_mode`, `smatrix_summary`, and `plot_field` with linear and log (dB)
+  scales; every solver's `plot_fields()` gained a `scale=` argument and draws
+  on the engine's true (non-uniform) grid. `gds_fdtd.modes.waveguide_mode`
+  solves strip modes offline via tidy3d's local plugin.
+- **Documentation overhaul**: the API reference now covers the whole public
+  surface (27 module pages, grouped by topic); new frontends guide (what a
+  frontend is, the built-ins, and how to write your own — verified example);
+  the technology page rebuilt around the three material sources and
+  refractiveindex.info; real figures throughout; sphinx-design landing page.
+- **Top-level API exports**: `from gds_fdtd import Technology, SimulationSpec,
+  get_solver` (joining `SMatrix` and the geometry classes).
+- **Convenience install extras**: `pip install gds_fdtd[all]` (every engine +
+  frontend) and `[engines]` (tidy3d + beamz).
+- **Property-based tests** (hypothesis, new dev dependency) for the numeric
+  core — S-matrix I/O round-trips, reciprocity/passivity invariants,
+  port-extension geometry, technology v1↔v2 equivalence — plus a real beamz
+  end-to-end test (slow-marked) in the CI all-extras leg. All-extras branch
+  coverage rose 81% → 90.2%; the CI gate ratcheted 80 → 90.
+- A written **deprecation policy** (CONTRIBUTING.md): two-minor-release
+  window, `DeprecationWarning` + CHANGELOG + a warning-asserting test.
 
 ### Fixed
 - `SMatrix.from_entries` (and therefore `SMatrix.from_dat`) rejected a
@@ -82,6 +113,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   malformed `.dat` claiming a ~10**6 mode id tried to allocate 623 TiB and
   raised `MemoryError`. It now raises a clean `ValueError` (found by the new
   `.dat` fuzz target).
+- `compare_smatrices`/`max_delta_db` no longer return `+inf` when one engine
+  has a dead (all-zero) column: values are clamped to the floor and compared
+  in dB, so partial results read as a bounded disagreement.
+- The tidy3d adapter crashed on lossy constant materials (`nk` with k > 0) by
+  building a complex permittivity; both call sites now use `Medium.from_nk`
+  (found live by the air-clad PSR run, whose superstrate is `nk: 1.0`).
+- beamz now honors `spec.buffer` and `spec.z_min`/`z_max` whenever they exceed
+  its physical guard-band floors (computed over all device layers, so
+  multilayer stacks get full clearance); default jobs are bit-identical.
+- Field plots render on the engine's true grid coordinates: tidy3d's adaptive
+  mesh drawn with a uniform `imshow` stretched the finely-meshed core ~2× and
+  made the waveguide look wider than simulated (setup-parity audit, example
+  06). All field figures and `plot_fields` now use `pcolormesh`.
+- `lyprocessor` port detection: a >2-point pin path *returned* an exception
+  instead of raising it, diagonal pins fell through silently, and an unlabeled
+  pin produced a `None` port name — all three now raise `LayoutError` (caught
+  by the whole-package strict-typing pass).
+- The tidy3d workdir now defaults under the current directory instead of the
+  system temp dir (often a small RAM-backed tmpfs), and result downloads are
+  routed there too — multi-GB field downloads no longer die with
+  `OSError 28: No space left on device`.
+- `smatrix_summary` uses an engineering reciprocity/passivity tolerance
+  (1e-2) suited to real FDTD output instead of flagging every physical result.
 
 ### Changed
 - (BREAKING) Renamed the technology-to-dict method: `Technology.to_legacy_dict()`
@@ -98,8 +152,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Tidy3DSolver` adapter is the only entry point; the engine base no longer
   imports the legacy `core.technology` type (it took the modern `Technology`
   in practice). No public API changed — all of these names are internal.
-- `mypy --strict` is now enforced on 13 modules (was 5), covering the whole
-  modern core; two latent type bugs were fixed in the process.
+- Errors raised on user-input paths (files, tech dicts, layouts, jobs,
+  results I/O) now derive from the `GdsFdtdError` hierarchy — including the
+  new `SMatrixError` — while dual-inheriting the builtin they replaced
+  (`ValueError`, `RuntimeError`, …), so existing `except` clauses keep
+  working. `materials.rii`'s missing-page error changed base from
+  `FileNotFoundError` to `TechnologyError` (still a `ValueError`).
+- `mypy --strict` now passes on the **whole package** (34 files) and is a
+  required CI gate (was: 13-module core + advisory rest).
+- The internal `_sparams` module logs through the package logger instead of
+  printing (library etiquette: silent unless logging is configured).
+- One unified project description across pyproject/README/docs.
 
 ### Security
 - Branch protection enabled on `main`; solo-friendly (PR + green CI +

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,158 +3,78 @@
 Living plan for the post-0.5.0 development arc. Any agent or contributor
 should be able to read this, understand the current state, and pick up work
 without losing context. Keep it current; move granular tracking to GitHub
-Issues under the `v0.5.1` milestone as items are picked up.
+Issues as items are picked up.
 
-## Where we are — v0.6.0 (breaking legacy cleanup; on `main`, not yet tagged)
+## Where we are — v0.6.0 (ready to tag)
 
 Solver-agnostic FDTD: one `Component` + one technology file + one
 `SimulationSpec`, any engine (tidy3d / Lumerical / beamz) behind
 `get_solver(name)(component, tech, spec)`. Three-engine agreement within
 0.052 dB on identical jobs (tidy3d↔Lumerical within 0.0033 dB), recorded and
-asserted every PR. Branch coverage ~82.7% (all-extras leg; base floor 75).
-Docs on GitHub Pages. OpenSSF Scorecard 7.0 (branch protection now enabled).
+asserted every PR. All-extras branch coverage 90.2% (gate: 90; base floor 75).
+`mypy --strict` passes on the whole package and is a required CI gate.
+Docs on GitHub Pages (actions-based flow). OpenSSF Scorecard: branch
+protection, signed releases, and CI fuzzing in place.
 
-**0.6.0 (breaking) — landed on `main` (PRs #27–#32), not yet tagged.** The
-staged legacy cleanup removed the entire pre-0.5 public surface: the
-`gds_fdtd.solver` / `solver_tidy3d` / `solver_lumerical` modules, the
-`core.technology` class + `core.parse_yaml_tech` + the whole `gds_fdtd.core`
-shim module, the `Technology.to_legacy_dict()` name (→ `to_solver_dict()`), and
-the public `gds_fdtd.sparams` module (→ internal `_sparams`). The supported API
-is `get_solver(name)` + `Technology` + `SimulationSpec` + `SMatrix`. See
-[`HANDOFF.md`](HANDOFF.md) for the full development arc and the live-validation
-runbook (tidy3d/Lumerical) — which has NOT been re-run since the cleanup.
+**0.6.0 highlights (all merged to `main`):**
 
-The modernization arc (Phases 0–7, ~80 commits) that produced 0.5.0 is complete
-and shipped; its plan has been retired. Deferred items are captured in the
-[Carry-forward backlog](#carry-forward-backlog) below.
+- **Breaking legacy cleanup** (PRs #27–#32): the entire pre-0.5 public surface
+  removed — `solver`/`solver_tidy3d`/`solver_lumerical`, `core`,
+  `to_legacy_dict` (→ `to_solver_dict`), public `sparams` (→ internal
+  `_sparams`). The supported API is `get_solver` + `Technology` +
+  `SimulationSpec` + `SMatrix`, all exported at the top level.
+- **Examples became an executed-notebook curriculum** (PR #34): 13 committed
+  notebooks (`00_quickstart` … `10b_polarization`) with real outputs, recorded
+  cross-engine artifacts (y-branch, sharp S-bend, crossing, escalator, PBS,
+  PSR), the frontend × engine matrix, and the material-source selection system
+  (`eda → rii → nk`).
+- **Docs overhaul**: full API reference (27 module pages), a frontends guide
+  (including "write your own"), the technology/materials page rebuilt around
+  refractiveindex.info, real figures throughout, one unified project
+  description.
+- **Hardening**: user-input raises routed through the `GdsFdtdError`
+  hierarchy; whole-package strict typing (caught three real bugs); property-
+  based tests (hypothesis) + a real beamz end-to-end test; deprecation policy
+  written (CONTRIBUTING.md).
+
+See [`HANDOFF.md`](HANDOFF.md) for the development arc and the live-validation
+runbook, and `CHANGELOG.md` for the full 0.6.0 entry.
 
 ## Guiding principles (non-negotiable)
 
 1. **Validate through the exact artifact users run** — example files in a
-   fresh interpreter/venv, not bespoke scripts sharing session state (this
-   is how the released 0.5.0 was found to break example 09 on a clean
-   install; see the de-slop PR #24).
+   fresh interpreter/venv, not bespoke scripts sharing session state.
 2. **No coverage theatre.** Every test asserts real behavior. A number that
    went up because a `pass` got executed is a regression, not progress.
 3. **Only `run()` spends** money / licenses / GPU. Constructors and
    `validate`/`build`/`estimate` stay offline, pure, deterministic.
 4. **Deferrals are documented, not silent.** If something can't be validated
    here (no GPU, no container runtime), it goes to the backlog with the
-   verified facts a future executor needs — never a blind implementation.
-5. **Every change is a PR into `main`.** No direct pushes. This is both good
-   hygiene and the path to the Scorecard Code-Review signal.
+   verified facts a future executor needs.
+5. **Every change is a PR into `main`.** No direct pushes.
 
-## v0.5.1 — the polish, hardening & trust arc
+## Completed workstreams (the 0.5.1→0.6.0 polish arc)
 
-Five workstreams. They are independent; parallelize freely.
+| Workstream | Outcome |
+|---|---|
+| **WS1 — Executed example notebooks** | DONE. 13 jupytext-paired notebooks, committed executed with real outputs; gallery renders in the docs via myst-nb; every simulation example shows its mode and its field; recorded artifacts carry PROVENANCE notes. |
+| **WS2 — Real >90% coverage** | DONE. All-extras branch coverage 90.2%, `--cov-fail-under=90` in CI; hypothesis property tests for the numeric core; a real (slow-marked) beamz end-to-end test runs in the all-extras leg. |
+| **WS3 — Robustness** | DONE. `GdsFdtdError` hierarchy on every user-input path (dual-inheriting the builtins); `mypy --strict` on all 34 source files as a required gate; top-level API exports; library-quiet logging; written deprecation policy. |
+| **WS4/WS5 — Tooling & Scorecard (partial)** | Signed releases (Sigstore) and CI fuzzing (atheris) landed. Remaining items below. |
 
-### WS1 — Examples become executed, verified notebooks
+## Remaining work (post-0.6.0)
 
-The example scripts are the front door. Turn them into notebooks with
-real, committed outputs (plots inline), executable end-to-end, and checked
-by CI. **Mostly done** (see remaining CI item below).
-
-- **Author format:** ✅ DONE. The `.py` scripts are the source of truth, paired
-  to notebooks with [jupytext](https://jupytext.readthedocs.io/) (percent
-  format), so notebooks are diff-friendly and never drift from the scripts. The
-  gallery is a clean numbered path `00_quickstart` … `10_cookbook` (11 notebooks);
-  the legacy flat `0X_name/` scripts were retired.
-- **Execution tiers:** ✅ DONE (locally). Every notebook is committed as its
-  executed `.ipynb` with real outputs. The whole gallery reproduces **for free**:
-  live runs use beamz (JAX/CPU) or tidy3d's free *local* mode solver; the
-  cross-engine comparisons (07, 10) load **recorded** tidy3d/Lumerical artifacts.
-  No notebook spends credits or a license.
-- **Gallery:** ✅ DONE. Executed notebooks render into the Sphinx docs via
-  [myst-nb](https://myst-nb.readthedocs.io/) (`nb_execution_mode = "off"` — the
-  committed outputs are shown as-is), so the website shows real field profiles
-  and S-parameters, not source alone.
-- **Cleanup:** ✅ DONE. The stray `examples/notebooks/faid/` notebook (pre-0.5,
-  unreferenced, once carried a base64 license token in its logs) was removed;
-  the numbered `examples/NN_*` set is the single source of truth.
-- **Remaining:** a *dedicated CI job* that re-executes the offline notebooks on
-  every PR (beamz + local + recorded, all free) and diffs outputs — today CI
-  guards them only via `tests/test_examples_importable.py` (imports resolve).
-- *Done when:* every example has a committed executed notebook ✅; the docs
-  gallery shows real outputs ✅; the offline set re-executes green in a dedicated
-  CI job (remaining).
-
-### WS2 — Real >90% coverage
-
-Current: 81% full-package. The gap is concentrated in the engine adapters
-(`solvers/beamz` 16%, `solvers/tidy3d` 45%, `layout/gdsfactory` 12% —
-low only because those extras aren't in the base test env) and in the legacy
-`solver_*` internals, `cli`, `caching`, `modes`.
-
-- **Measure the right thing:** the >90% bar is enforced on the **all-extras**
-  CI leg (engines installed), not the base profile. Raise
-  `--cov-fail-under` there step by step as real tests land; ratchet only up.
-- **Property-based tests** (hypothesis) for the numeric core — `SMatrix`
-  (reciprocity/passivity invariants, round-trip through every I/O format),
-  `geometry` (dilate/extension math), `technology` (v1↔v2 equivalence),
-  `grid`/`extraction` (energy/overlap identities). These double as the
-  fuzzing signal (see WS5).
-- **beamz** is free and CPU-runnable → real (small, `@pytest.mark.slow`)
-  end-to-end tests in the all-extras leg, not mocks alone.
-- **gdsfactory / mode solver** run offline locally → real conversion and
-  n_eff tests.
-- *Done when:* all-extras leg ≥ 90% branch coverage, every new test asserts
-  behavior, and the base-profile floor also rises where warranted.
-
-### WS3 — De-slop & refactor for robustness
-
-The released 0.5.0 is clean at the surface; the depth to attack is the
-**legacy `solver_*` layer** the modern adapters wrap.
-
-- **Flatten the legacy wrap:** ✅ DONE (0.6.0). `solver_lumerical.py`
-  (pure duplicate) and `solver_tidy3d.py` (deprecated alias) were removed;
-  the base `solver.py` moved to the internal `solvers/_tidy3d_base.py` and
-  the public `gds_fdtd.solver` module was removed. The Tidy3D scene-building
-  engine is now internal (`solvers/_tidy3d_engine`), and the supported
-  surface is `solvers/` (`get_solver` + the adapters) only. ~1050 lines of
-  pre-0.5 public API deleted; documented as a breaking 0.6.0 change.
-- **Errors everywhere:** audit every `raise` in user-input paths → the
-  `GdsFdtdError` hierarchy; no bare `except:`.
-- **Types:** extend `mypy --strict` module-by-module beyond the current
-  typed core until the whole package is strict-clean; then make it a hard
-  gate.
-- **Consistency pass:** logging (no residual prints), docstring style,
-  public API surface (`__all__`), and a documented deprecation policy.
-
-### WS4 — Workflow, tooling & release modernization
-
-- **Signed releases** (also WS5): sign wheels+sdist with Sigstore in
-  `release.yml`, attach `.sigstore` bundles to the GitHub Release.
-- **Fuzzing** (also WS5): atheris fuzz targets on the parsers (run directly in CI).
-- **Coverage reporting:** wire codecov `project`/`patch` gates so PRs that
-  drop coverage fail; surface the number on the PR.
-- **Dependency freshness canary:** alongside the weekly lowest-floors job,
-  add an allowed-failure "latest unpinned" job so upstream breakage is seen
-  early.
-- **Notebook CI** (WS1) and **docs link-check** jobs.
-- **Merge queue** once branch protection lands (WS5).
-
-### WS5 — OpenSSF Scorecard: 7.0 → as high as a solo-maintained repo can go
-
-Current failing/low checks and the concrete action for each. Weights:
-CRITICAL/HIGH move the needle most.
-
-| Check | Now | Weight | Action | Who |
-|---|---|---|---|---|
-| **Branch-Protection** | ✅ | HIGH | DONE — `main` requires a PR + the passing `pass` check + up-to-date branches + linear history; force-pushes blocked; enforced for admins. Solo-friendly: 0 required reviews (raising this needs a second maintainer / review bot). | owner ✅ |
-| **Code-Review** | 0 | HIGH | Route *all* changes through PRs (principle 5) and get an approving review before merge. Solo dev is the ceiling here — a second reviewer/maintainer or a review bot is the only way to fully satisfy it. | owner + process |
-| **Signed-Releases** | 0 | HIGH | Sigstore-sign release artifacts in `release.yml`; attach signatures to the GitHub Release. (PyPI already gets PEP 740 attestations via trusted publishing.) | executor (workflow) |
-| **Fuzzing** | 0 | MEDIUM | atheris fuzz targets on the technology-YAML and `.dat` parsers, run directly in CI (import atheris is the Scorecard signal). | executor |
-| **Packaging** | ? | MEDIUM | Resolves to 10 once the package publishes to PyPI via the recognized workflow — pending Lukas registering the trusted publisher. | pending PyPI |
-| **CII-Best-Practices** | 0 | LOW | Register at bestpractices.dev and complete the passing questionnaire (we already meet most: VCS, tests, CI, docs, license, CONTRIBUTING, SECURITY, no known vulns). Executor can pre-fill answers. | owner registers |
-
-Everything else is already 10 (Dangerous-Workflow, Maintained,
-Dependency-Update-Tool, Binary-Artifacts, Token-Permissions, Vulnerabilities,
-Security-Policy, Pinned-Dependencies, SAST, License, Contributors, CI-Tests).
-
-*Honest target:* Branch-Protection + Signed-Releases + Fuzzing + Packaging
-should lift the score to ~8.5–9.0. A perfect 10 is unrealistic for a
-single-maintainer project (Code-Review and full Fuzzing credit are the
-structural ceilings) — we max what's real and don't game the rest.
+- **Notebook-execution CI job** (WS1 leftover): re-execute the offline
+  notebooks (beamz + local + recorded, all free) on PRs and diff outputs.
+  Today CI guards them via `tests/test_examples_importable.py` only.
+- **Codecov project/patch gates** so PRs that drop coverage fail visibly.
+- **Dependency freshness canary**: an allowed-failure "latest unpinned" job
+  alongside the weekly lowest-floors job.
+- **Docs link-check** job; **merge queue** (serializes the up-to-date-branch
+  dance the dependabot trains currently do manually).
+- **Scorecard**: Packaging resolves once the PyPI trusted publisher is
+  registered; CII Best-Practices badge is an owner registration;
+  Code-Review score is structurally capped for a solo maintainer.
 
 ## Feature ideas (menu — pick as inspiration strikes)
 
@@ -173,41 +93,39 @@ Not committed; a palette to choose from. Roughly ordered by impact.
   npz cache (e.g. an S3/GCS-backed cache for cluster sweeps).
 - **Interactive report** — an HTML/notebook report per run (geometry,
   convergence, S-params, fields) as a single shareable artifact.
-- **Richer technology** — anisotropic/dispersive material helpers,
-  gdsfactory `LayerStack` / KLayout `.lyt` import into technology v2.
+- **Richer technology** — anisotropic material helpers, gdsfactory
+  `LayerStack` / KLayout `.lyt` import into technology v2.
 - **Multi-frequency / broadband mode tracking**, bend-mode solving, PML
   convergence diagnostics.
+- **beamz TM / multimode** — 10b showed beamz is TE-only; upstream beamz
+  work plus adapter support would complete the free-engine polarization story.
 
-## Carry-forward backlog (from the modernization arc)
-
-Deferred with documented rationale; resume when the blocker clears.
+## Carry-forward backlog (deferred with rationale)
 
 - **fdtdz adapter (D9)** — needs an NVIDIA GPU + CUDA (fdtdz ships a
   CUDA-building sdist; won't even import without it). Verified kernel API and
   constraints recorded in git history. Natural to pair with a GPU CI lane.
 - **femwell mode-solver backend (D8)** — second `ModeSolver` backend; the
   tidy3d local plugin already covers Tier-B needs at zero extra deps.
-- **MEEP adapter** — deprioritized by owner; beamz fills the free-engine
-  role.
+- **MEEP adapter** — deprioritized by owner; beamz fills the free-engine role.
 - **Container images (ghcr) + conda-forge feedstock** — no container runtime
   on the dev machine to validate images; feedstock is owner-level.
 - **tenacity retries on cloud calls** — modifying validated money-spending
   paths deserves its own live-revalidation session; make task submission
   idempotent (`task_name = gdsfdtd-{job_hash[:12]}`) first.
 - **CITATION.cff** + Zenodo DOI for academic citation.
-- **v1.0** — freeze the public API and finalize the deprecation policy. (The
-  `core` and `solver_*` shims were removed early, in 0.6.0; the remaining
-  `Component.structures` nested-list deprecation shim is the last one to retire.)
+- **v1.0** — freeze the public API per the deprecation policy; the remaining
+  `Component.structures` nested-list shim is the last deprecation to retire.
 
 ## Owner-only actions (need admin / external accounts)
 
-Tracked here so they don't get lost; none block executor work.
-
-- [x] **Branch protection on `main`** (WS5) — ✅ enabled: PR + green `pass` +
-      up-to-date + linear history required, force-pushes blocked, admins enforced.
+- [x] **Branch protection on `main`** — PR + green `pass` + up-to-date +
+      linear history required, force-pushes blocked, admins enforced.
+- [x] **Pages source = GitHub Actions** — the artifact-based docs deploy is live.
 - [ ] **PyPI trusted publisher** (project `gds_fdtd`, owner `SiEPIC`,
-      workflow `release.yml`, env `pypi`) — in progress with Lukas; then
-      re-run the release build's publish job. Unlocks Packaging (WS5).
+      workflow `release.yml`, env `pypi`) — in progress with Lukas; until it
+      lands, tagged releases produce signed GitHub artifacts but the PyPI
+      publish step cannot run.
 - [ ] **OpenSSF Best Practices badge** — register at bestpractices.dev.
 - [ ] **`cloud-tests` environment** with a required reviewer (guards the
       budget-gated tidy3d smoke).
@@ -219,7 +137,6 @@ Tracked here so they don't get lost; none block executor work.
 ## Tracking
 
 - This file = the durable plan.
-- Granular work = GitHub Issues under a **`v0.5.1`** milestone, one issue per
-  task above, linked from the PR that closes it.
-- Every PR targets `main`, passes the full matrix, and is squash- or
-  merge-committed only after review.
+- Granular work = GitHub Issues, one issue per remaining item above, linked
+  from the PR that closes it.
+- Every PR targets `main` and passes the full matrix before merge.


### PR DESCRIPTION
Release-notes housekeeping ahead of the v0.6.0 tag:

- **CHANGELOG**: the Unreleased section becomes `[0.6.0] - 2026-07-15`, extended
  with everything that landed since it was drafted — the executed-notebook
  curriculum (13 notebooks, frontend × engine matrix, polarization devices),
  the visualization toolkit (log-scale fields, modes, stacks), the docs
  overhaul (full API reference, frontends guide, technology/rii), top-level
  API exports, the `all`/`engines` install extras, hypothesis + beamz e2e
  tests with the coverage gate at 90, the deprecation policy, and the round of
  fixes (bounded cross-solver deltas, `Medium.from_nk`, beamz buffer/z-window,
  true-grid field rendering, lyprocessor pin handling, tmpfs-safe tidy3d
  downloads).
- **ROADMAP**: rewritten to the post-0.6.0 state — WS1/WS2/WS3 recorded as
  complete with outcomes, remaining tooling items listed as post-0.6.0 work,
  owner actions updated (Pages flow live; PyPI trusted publisher pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)