### PR TITLE
fix(gdsfactory): merge abutting polygons per layer before extrusion

### DIFF
--- a/src/gds_fdtd/layout/gdsfactory.py
+++ b/src/gds_fdtd/layout/gdsfactory.py
@@ -59,6 +59,35 @@ def _ensure_trailing_digits(name: str, fallback_index: int) -> str:
     return new
 
 
+_MERGE_DBU_UM = 0.001  # 1 nm merge grid, matching the usual GDS dbu
+
+
+def _merge_layer_polygons(polygons: list[Any]) -> list[list[list[float]]]:
+    """Union the polygons of one layer into merged simple polygons (um floats).
+
+    Abutting polygons (a hierarchical gdsfactory component returns one polygon
+    per placed reference) must extrude as ONE body: with a sidewall angle each
+    polygon tapers from its own footprint, so every internal junction opens a
+    wedge-shaped gap in the sloped faces (issue #1). The KLayout GDS loader
+    already merges per layer (``pya.Region.merge()``); this applies the same
+    proven pipeline — including hole handling via ``to_simple_polygon`` — to
+    the gdsfactory frontend. Coordinates snap to a 1 nm grid, the standard
+    GDS dbu.
+    """
+    import pya
+
+    region = pya.Region()
+    for pts in polygons:
+        arr = np.asarray(pts, dtype=float) / _MERGE_DBU_UM
+        region.insert(pya.Polygon([pya.Point(int(round(x)), int(round(y))) for x, y in arr]))
+    region.merge()
+    merged: list[list[list[float]]] = []
+    for poly in region.each_merged():
+        simple = poly.to_simple_polygon()
+        merged.append([[pt.x * _MERGE_DBU_UM, pt.y * _MERGE_DBU_UM] for pt in simple.each_point()])
+    return merged
+
+
 def from_gdsfactory(c: Any, tech: Any, z_span: float = 4.0) -> Component:
     """Convert a gdsfactory (>=9) Component into a gds_fdtd Component.
 
@@ -80,7 +109,9 @@ def from_gdsfactory(c: Any, tech: Any, z_span: float = 4.0) -> Component:
     tech_dict = tech.to_solver_dict() if hasattr(tech, "to_solver_dict") else tech
     device_layers = {tuple(d["layer"]): d for d in tech_dict["device"]}
 
-    # ---- structures: one per polygon per tech-declared device layer ----
+    # ---- structures: one per MERGED polygon per tech-declared device layer ----
+    # (abutting per-reference polygons union into one body so angled sidewalls
+    # cannot open gaps at internal junctions — issue #1)
     structures: list[Structure] = []
     polygons_by_layer = c.get_polygons_points(by="tuple")
     for layer_tuple, polygons in polygons_by_layer.items():
@@ -88,12 +119,11 @@ def from_gdsfactory(c: Any, tech: Any, z_span: float = 4.0) -> Component:
         if d is None:
             logger.info("layer %s present in component but not in technology; skipped", layer_tuple)
             continue
-        for i, pts in enumerate(polygons):
-            arr = np.asarray(pts, dtype=float)
+        for i, pts in enumerate(_merge_layer_polygons(polygons)):
             structures.append(
                 Structure(
                     name=f"poly_{layer_tuple[0]}_{layer_tuple[1]}_{i}",
-                    polygon=arr.tolist(),
+                    polygon=pts,
                     z_base=d["z_base"],
                     z_span=d["z_span"],
                     material=get_material(d),

--- a/tests/test_gdsfactory.py
+++ b/tests/test_gdsfactory.py
@@ -111,3 +111,42 @@ def test_legacy_simprocessor_delegate(tech):
 
     comp = legacy(gf.components.straight(length=10), tech)
     assert {p.name for p in comp.ports} == {"o1", "o2"}
+
+
+def test_abutting_reference_polygons_merge_into_one_body(tech):
+    """Issue #1: a hierarchical component (one polygon per placed reference)
+    must extrude as ONE body per connected region — separate abutting polygons
+    each taper from their own footprint under a sidewall angle, opening
+    wedge-shaped gaps at every internal junction."""
+    import shapely
+
+    c = gf.Component()
+    s1 = c.add_ref(gf.components.straight(length=3))
+    b = c.add_ref(gf.components.bend_euler(radius=5))
+    b.connect("o1", s1.ports["o2"])
+    s2 = c.add_ref(gf.components.straight(length=3))
+    s2.connect("o1", b.ports["o2"])
+    c.add_port("o1", port=s1.ports["o1"])
+    c.add_port("o2", port=s2.ports["o2"])
+
+    comp = from_gdsfactory(c, tech)
+    devices = [s for s in comp.structures if s.role == "device"]
+    assert len(devices) == 1, [d.name for d in devices]  # 3 abutting refs -> 1 body
+    merged = shapely.Polygon(devices[0].polygon)
+    assert merged.is_valid
+    # area is preserved by the union (straights 2 x 3x0.5 + the bend body)
+    assert merged.area > 2 * 3 * 0.5
+
+
+def test_disjoint_polygons_stay_separate(tech):
+    """The merge must not fuse bodies that do not touch."""
+    c = gf.Component()
+    s1 = c.add_ref(gf.components.straight(length=2))
+    s2 = c.add_ref(gf.components.straight(length=2))
+    s2.move((0, 5))  # far apart
+    c.add_port("o1", port=s1.ports["o1"])
+    c.add_port("o2", port=s2.ports["o2"])
+
+    comp = from_gdsfactory(c, tech)
+    devices = [s for s in comp.structures if s.role == "device"]
+    assert len(devices) == 2


### PR DESCRIPTION
Fixes #1 — "Angled polygons will create gaps in connected structures when using from_gdsfactory".

**Cause.** A hierarchical gdsfactory component returns one polygon per placed reference. Each polygon extrudes independently, and a sidewall angle tapers each from its *own* footprint — so every internal junction between abutting references opens a wedge-shaped gap in the sloped faces (the seams visible in the tidy3d viewer between `poly_*` slabs).

**Fix.** `from_gdsfactory` now unions the polygons of each device layer before creating structures, using the same proven KLayout pipeline the raw-GDS loader has always used (`pya.Region.merge()` + `to_simple_polygon()`, which also handles holes), snapped to a 1 nm grid. Connected regions extrude as one body on every engine; disjoint bodies remain separate.

**Verified.** A straight + euler-bend + straight hierarchy went from 3 abutting device polygons to 1 valid merged polygon (area preserved). Regression tests cover both the merge and the no-over-merge (disjoint) case. Suite: 376 passed; mypy --strict clean.
