### PR TITLE
release: v0.6.1 — harden the 3D viewer, complete docs/changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.1] - 2026-07-21
 
 ### Added
 - Interactive 3D viewer (`gds_fdtd.viewer3d`): `show_3d(solver_or_component)`
@@ -24,7 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `plot_component` draws the mode planes (dimensions in the legend, which now
   sits outside the axes where it no longer hides top ports),
   `port_plane_outlines()` adds them to field-map overlays, and
-  `component_outlines(buffer=)` outlines the extension stubs.
+  `component_outlines(buffer=)` outlines the extension stubs. The scene renders
+  at true 1:1:1 proportions by default, with an opt-in "z ×4" legend toggle
+  that exaggerates thin layers for inspecting a stack.
 - Field monitors are steerable and visible: `SimulationSpec.field_monitor_positions`
   pins any monitor plane at an absolute coordinate along its normal axis, and
   `SimulationSpec.field_monitor_wavelengths` restricts what the monitors record
@@ -42,7 +44,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wavelength — reflection in-band vs transmission out-of-band from a single
   run). Both ship recorded artifacts with provenance.
 
+### Security
+- The 3D viewer now escapes all user-derived strings before embedding them.
+  Component, structure, and port names (and material labels) come from
+  arbitrary GDS files and were substituted verbatim into the viewer's
+  `<script>` block and info panel, so a name containing `</script>` or markup
+  could inject executable HTML/JS — a real risk for shared `save_3d` output.
+  The scene JSON is now `\uXXXX`-escaped for the script context and the
+  component name reaches the DOM only through `textContent` (never parsed as
+  HTML). Verified against a headless-browser injection probe.
+
 ### Fixed
+- The 3D viewer renders in every notebook renderer: it emits an
+  `<iframe srcdoc>` (the one embed whose scripts execute under JupyterLab's
+  innerHTML insertion, VSCode's shadow-DOM webviews, and static docs pages
+  alike) wrapping classic (non-module) three.js, with unique per-emission ids,
+  a shadow-DOM-aware element finder, and boot-stage captions that name any
+  failure in the panel instead of a blank rectangle.
+- The viewer's static `render_static` derives axis limits from the structure
+  extents when no simulation domain is present, disables matplotlib's 3D
+  autoscale on the collections (whose margin math could overflow to `inf`),
+  and uses a true box aspect — matching the interactive viewer's 1:1 default.
+  Repeated z-scale toggles now dispose GPU geometries/materials/textures.
+- The subprocess job runner closes its open log file handle if the child
+  process fails to launch, instead of leaking it on that error path.
 - The `filterwarnings = ["error::DeprecationWarning:gds_fdtd.*"]` guard sat
   under `[tool.coverage.report]`, where pytest never read it — moved to
   `[tool.pytest.ini_options]`, so in-package deprecation warnings fail tests
@@ -58,9 +83,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the remaining violations were fixed (mutable default arguments in
   `lyprocessor`, a swallowed exception chain in `simprocessor`, a dead
   variable, 36 long lines wrapped) and the lint config now carries no ignores.
-  Unused dev dependencies (`twine`, `watchdog`, `wheel`) were dropped, stale
-  docs figures deleted, and `HANDOFF.md`/`ROADMAP.md`/`SOLVER_STATUS.md`
-  refreshed to the post-release state.
+  Unused dev dependencies (`twine`, `watchdog`, `wheel`, and `sphinx-rtd-theme`
+  — the docs build on furo) were dropped, stale docs figures deleted, and
+  `HANDOFF.md`/`ROADMAP.md`/`SOLVER_STATUS.md` refreshed to the post-release
+  state.
+- Dependency floors raised across the board (numpy ≥ 2.4.6, shapely ≥ 2.1.2,
+  klayout ≥ 0.30.9, SiEPIC ≥ 0.5.31; dev: ruff ≥ 0.15.22, mypy ≥ 2.3.0,
+  pip ≥ 26.1.2, codespell ≥ 2.4.3, sphinx-toggleprompt), with `uv.lock`
+  re-synced, and the pinned GitHub Actions bumped to current releases
+  (setup-uv, gh-action-pypi-publish, codeql-action, configure-pages,
+  action-gh-release).
 - The reference `examples/tech.yaml` now demonstrates material-source pinning
   live: the substrate material (`SiO2_rii`) carries eda + rii + nk sources and
   sets `source: rii`, so every engine models the buried oxide from the same

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -6,12 +6,16 @@ the compressed history and the working conventions; the live plan is
 [`SOLVER_STATUS.md`](SOLVER_STATUS.md), and user-facing docs live at
 <https://siepic.github.io/gds_fdtd/>.
 
-**State:** `v0.6.0` is released (tagged 2026-07-15, signed GitHub release).
+**State:** `v0.6.1` is released (tagged 2026-07-21, signed GitHub release).
+It adds the interactive 3D viewer (`gds_fdtd.viewer3d.show_3d`), steerable and
+visible field monitors (`SimulationSpec.field_monitor_positions` /
+`field_monitor_wavelengths`, `plot_monitor_planes`), and two examples
+(`05b_field_monitors`, `11_bragg_grating`) on top of `v0.6.0` (2026-07-15).
 The three engines were validated **live** against each other during the 0.6
 arc — tidy3d ↔ Lumerical within 0.0033 dB, beamz within 0.052 dB on the
 identical job — and that agreement is locked into CI through recorded
 artifacts. All-extras branch coverage is ≥90 (gated), `mypy --strict` passes
-on the whole package (required check), and the examples are 13 executed
+on the whole package (required check), and the examples are 15 executed
 notebooks with committed outputs. The one loose end is the PyPI trusted
 publisher (owner action; PyPI still serves 0.4.0 — see ROADMAP).
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The version is derived **from git tags** via `hatch-vcs` — there is nothing to
 version string in the source. To release:
 
 ```bash
-git tag v0.6.0
+git tag v0.6.1
 git push --tags
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,10 +5,16 @@ should be able to read this, understand the current state, and pick up work
 without losing context. Keep it current; move granular tracking to GitHub
 Issues as items are picked up.
 
-## Where we are — v0.6.0 (released 2026-07-15)
+## Where we are — v0.6.1 (released 2026-07-21)
 
-`v0.6.0` is tagged with a signed GitHub release (Sigstore bundles + SBOM).
-The PyPI upload is the one step still blocked — see the owner actions below.
+`v0.6.1` is tagged with a signed GitHub release (Sigstore bundles + SBOM),
+building on `v0.6.0` (2026-07-15). It adds the interactive 3D viewer
+(`viewer3d.show_3d` / `save_3d` / `render_static`), steerable field monitors
+(`field_monitor_positions` / `field_monitor_wavelengths`, `plot_monitor_planes`),
+and examples `05b_field_monitors` + `11_bragg_grating`; it hardens the viewer
+against HTML/JS injection from GDS-derived names and makes its embed render
+across JupyterLab / VSCode / static docs. The PyPI upload is the one step
+still blocked — see the owner actions below.
 
 Solver-agnostic FDTD: one `Component` + one technology file + one
 `SimulationSpec`, any engine (tidy3d / Lumerical / beamz) behind
@@ -128,9 +134,9 @@ Not committed; a palette to choose from. Roughly ordered by impact.
 - [ ] **PyPI trusted publisher** (project `gds_fdtd`, owner `SiEPIC`,
       workflow `release.yml`, env `pypi`) — in progress with Lukas; until it
       lands, tagged releases produce signed GitHub artifacts but the PyPI
-      publish step cannot run (re-verified 2026-07-17: `invalid-publisher`,
+      publish step cannot run (re-verified 2026-07-21: `invalid-publisher`,
       PyPI still serves 0.4.0). Once registered, re-run the failed publish job
-      of the v0.6.0 Release run.
+      of the latest (v0.6.1) Release run.
 - [ ] **OpenSSF Best Practices badge** — register at bestpractices.dev.
 - [ ] **`cloud-tests` environment** with a required reviewer (guards the
       budget-gated tidy3d smoke).

--- a/docs/simulations.rst
+++ b/docs/simulations.rst
@@ -84,9 +84,10 @@ wavelength selection to watch one device reflect in-band and transmit
 out-of-band from a single run.
 
 The whole setup also renders as an **interactive 3D scene** — the extruded
-layer stack with per-layer colors, the port cones, the monitor planes, and
-the domain box; orbit, zoom, click an object for its material and z-extent,
-and toggle groups from the legend:
+layer stack with per-layer colors, the port cones, each port's mode plane at
+its real ``width_ports × depth_ports`` (with a dimensions label), the
+extension stubs, the monitor planes, and the domain box; orbit, zoom, click an
+object for its material and z-extent, and toggle groups from the legend:
 
 .. code-block:: python
 
@@ -95,6 +96,20 @@ and toggle groups from the legend:
     show_3d(solver)                     # notebooks AND these docs (three.js)
     save_3d(solver, "device_3d.html")   # standalone shareable page
     render_static(solver)               # matplotlib, for JS-free contexts
+
+The scene shows **true 1:1:1 proportions** by default (a 220 nm layer really is
+hair-thin beside a many-µm device); the legend's *z ×4* checkbox exaggerates
+the vertical axis when you want to inspect a thin stack. ``render_static``
+draws the identical scene with matplotlib for the README and other JS-free
+contexts:
+
+.. figure:: images/escalator_3d.png
+   :width: 90%
+   :align: center
+
+   ``render_static`` of the Si→SiN escalator solver: the two cores, the
+   translucent cladding, the port mode planes, the monitor planes, and the
+   domain box — the same scene ``show_3d`` renders interactively.
 
 The 3D views embedded in :doc:`_notebooks/01_layout_to_component`,
 :doc:`_notebooks/05b_field_monitors`, and :doc:`_notebooks/11_bragg_grating`

--- a/examples/01_layout_to_component/01_layout_to_component.ipynb
+++ b/examples/01_layout_to_component/01_layout_to_component.ipynb
@@ -21,10 +21,10 @@
    "id": "0ae64e67",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T03:38:17.200164Z",
-     "iopub.status.busy": "2026-07-20T03:38:17.199990Z",
-     "iopub.status.idle": "2026-07-20T03:38:17.675948Z",
-     "shell.execute_reply": "2026-07-20T03:38:17.675325Z"
+     "iopub.execute_input": "2026-07-21T07:26:10.818002Z",
+     "iopub.status.busy": "2026-07-21T07:26:10.817880Z",
+     "iopub.status.idle": "2026-07-21T07:26:11.452730Z",
+     "shell.execute_reply": "2026-07-21T07:26:11.452248Z"
     }
    },
    "outputs": [],
@@ -66,24 +66,24 @@
    "id": "cc2d777a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T03:38:17.678217Z",
-     "iopub.status.busy": "2026-07-20T03:38:17.677947Z",
-     "iopub.status.idle": "2026-07-20T03:38:18.929173Z",
-     "shell.execute_reply": "2026-07-20T03:38:18.928637Z"
+     "iopub.execute_input": "2026-07-21T07:26:11.455194Z",
+     "iopub.status.busy": "2026-07-21T07:26:11.454944Z",
+     "iopub.status.idle": "2026-07-21T07:26:12.994688Z",
+     "shell.execute_reply": "2026-07-21T07:26:12.994099Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">20:38:17 PDT </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: Using canonical configuration directory at                </span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">00:26:11 PDT </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: Using canonical configuration directory at                </span>\n",
        "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span><span style=\"color: #008000; text-decoration-color: #008000\">'/home/mustafa/.config/tidy3d'</span><span style=\"color: #800000; text-decoration-color: #800000\">. Found legacy directory at          </span>\n",
        "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span><span style=\"color: #008000; text-decoration-color: #008000\">'~/.tidy3d'</span><span style=\"color: #800000; text-decoration-color: #800000\">, which will be ignored. Remove it manually or run      </span>\n",
        "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span><span style=\"color: #008000; text-decoration-color: #008000\">'tidy3d config migrate --delete-legacy'</span><span style=\"color: #800000; text-decoration-color: #800000\"> to clean up.               </span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m20:38:17 PDT\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: Using canonical configuration directory at                \u001b[0m\n",
+       "\u001b[2;36m00:26:11 PDT\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: Using canonical configuration directory at                \u001b[0m\n",
        "\u001b[2;36m             \u001b[0m\u001b[32m'/home/mustafa/.config/tidy3d'\u001b[0m\u001b[31m. Found legacy directory at          \u001b[0m\n",
        "\u001b[2;36m             \u001b[0m\u001b[32m'~/.tidy3d'\u001b[0m\u001b[31m, which will be ignored. Remove it manually or run      \u001b[0m\n",
        "\u001b[2;36m             \u001b[0m\u001b[32m'tidy3d config migrate --delete-legacy'\u001b[0m\u001b[31m to clean up.               \u001b[0m\n"
@@ -125,10 +125,10 @@
    "id": "a1719883",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T03:38:18.931433Z",
-     "iopub.status.busy": "2026-07-20T03:38:18.931022Z",
-     "iopub.status.idle": "2026-07-20T03:38:18.934037Z",
-     "shell.execute_reply": "2026-07-20T03:38:18.933326Z"
+     "iopub.execute_input": "2026-07-21T07:26:12.995715Z",
+     "iopub.status.busy": "2026-07-21T07:26:12.995503Z",
+     "iopub.status.idle": "2026-07-21T07:26:12.997839Z",
+     "shell.execute_reply": "2026-07-21T07:26:12.997484Z"
     }
    },
    "outputs": [
@@ -167,10 +167,10 @@
    "id": "529db6e0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T03:38:18.935802Z",
-     "iopub.status.busy": "2026-07-20T03:38:18.935611Z",
-     "iopub.status.idle": "2026-07-20T03:38:18.940010Z",
-     "shell.execute_reply": "2026-07-20T03:38:18.939038Z"
+     "iopub.execute_input": "2026-07-21T07:26:12.998510Z",
+     "iopub.status.busy": "2026-07-21T07:26:12.998450Z",
+     "iopub.status.idle": "2026-07-21T07:26:13.000623Z",
+     "shell.execute_reply": "2026-07-21T07:26:13.000252Z"
     }
    },
    "outputs": [
@@ -213,10 +213,10 @@
    "id": "06932958",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T03:38:18.941700Z",
-     "iopub.status.busy": "2026-07-20T03:38:18.941550Z",
-     "iopub.status.idle": "2026-07-20T03:38:19.096056Z",
-     "shell.execute_reply": "2026-07-20T03:38:19.094734Z"
+     "iopub.execute_input": "2026-07-21T07:26:13.001358Z",
+     "iopub.status.busy": "2026-07-21T07:26:13.001298Z",
+     "iopub.status.idle": "2026-07-21T07:26:13.134272Z",
+     "shell.execute_reply": "2026-07-21T07:26:13.133456Z"
     }
    },
    "outputs": [
@@ -256,19 +256,19 @@
    "id": "a040eaf4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T03:38:19.097382Z",
-     "iopub.status.busy": "2026-07-20T03:38:19.097303Z",
-     "iopub.status.idle": "2026-07-20T03:38:19.101657Z",
-     "shell.execute_reply": "2026-07-20T03:38:19.100855Z"
+     "iopub.execute_input": "2026-07-21T07:26:13.135583Z",
+     "iopub.status.busy": "2026-07-21T07:26:13.135486Z",
+     "iopub.status.idle": "2026-07-21T07:26:13.139859Z",
+     "shell.execute_reply": "2026-07-21T07:26:13.139500Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<iframe srcdoc=\"<div id=&quot;gdsfdtd3d_d71504d2ed&quot; style=&quot;position:relative;width:100%;height:420px;background:#101418;border-radius:8px;overflow:hidden;font-family:system-ui,sans-serif&quot;>\n",
-       "  <div id=&quot;gdsfdtd3d_d71504d2ed_info&quot; style=&quot;position:absolute;left:10px;top:10px;z-index:2;color:#dde3ea;font-size:12px;background:rgba(16,20,24,.75);padding:6px 10px;border-radius:6px;max-width:65%&quot;>crossing_te1550 — loading 3D viewer…</div>\n",
-       "  <div id=&quot;gdsfdtd3d_d71504d2ed_legend&quot; style=&quot;position:absolute;right:10px;top:10px;z-index:2;color:#dde3ea;font-size:12px;background:rgba(16,20,24,.75);padding:6px 10px;border-radius:6px&quot;></div>\n",
+       "<iframe srcdoc=\"<div id=&quot;gdsfdtd3d_f22f3ad5bc&quot; style=&quot;position:relative;width:100%;height:420px;background:#101418;border-radius:8px;overflow:hidden;font-family:system-ui,sans-serif&quot;>\n",
+       "  <div id=&quot;gdsfdtd3d_f22f3ad5bc_info&quot; style=&quot;position:absolute;left:10px;top:10px;z-index:2;color:#dde3ea;font-size:12px;background:rgba(16,20,24,.75);padding:6px 10px;border-radius:6px;max-width:65%&quot;>loading 3D viewer…</div>\n",
+       "  <div id=&quot;gdsfdtd3d_f22f3ad5bc_legend&quot; style=&quot;position:absolute;right:10px;top:10px;z-index:2;color:#dde3ea;font-size:12px;background:rgba(16,20,24,.75);padding:6px 10px;border-radius:6px&quot;></div>\n",
        "</div>\n",
        "<script>\n",
        "(function () {\n",
@@ -312,9 +312,9 @@
        "}\n",
        "\n",
        "function start(attempt) {\n",
-       "var host = findEl(&quot;gdsfdtd3d_d71504d2ed&quot;);\n",
-       "var info = findEl(&quot;gdsfdtd3d_d71504d2ed_info&quot;);\n",
-       "var legendBox = findEl(&quot;gdsfdtd3d_d71504d2ed_legend&quot;);\n",
+       "var host = findEl(&quot;gdsfdtd3d_f22f3ad5bc&quot;);\n",
+       "var info = findEl(&quot;gdsfdtd3d_f22f3ad5bc_info&quot;);\n",
+       "var legendBox = findEl(&quot;gdsfdtd3d_f22f3ad5bc_legend&quot;);\n",
        "if (!host || !info || !legendBox) {\n",
        "  if (attempt < 25) setTimeout(function () { start(attempt + 1); }, 120);\n",
        "  return;\n",
@@ -322,7 +322,8 @@
        "\n",
        "// boot stages are written into the panel: a failure names itself instead of\n",
        "// leaving a silent black rectangle\n",
-       "function stage(msg) { info.textContent = &quot;crossing_te1550 — &quot; + msg; }\n",
+       "// SCENE.name reaches the DOM only via textContent, which never parses HTML\n",
+       "function stage(msg) { info.textContent = (SCENE.name || &quot;component&quot;) + &quot; — &quot; + msg; }\n",
        "function fail(msg) {\n",
        "  info.textContent = &quot;3D viewer: &quot; + msg +\n",
        "    &quot; — use viewer3d.render_static for a static view.&quot;;\n",
@@ -418,7 +419,20 @@
        "const controls = new OrbitControls(camera, renderer.domElement);\n",
        "controls.enableDamping = true;\n",
        "\n",
+       "function disposeTree(obj) {\n",
+       "  // three.js does not free GPU memory on JS GC; release geometries, materials\n",
+       "  // and textures explicitly so repeated z-scale rebuilds do not leak VRAM\n",
+       "  obj.traverse(function (n) {\n",
+       "    if (n.geometry) n.geometry.dispose();\n",
+       "    if (n.material) {\n",
+       "      var mats = Array.isArray(n.material) ? n.material : [n.material];\n",
+       "      mats.forEach(function (m) { if (m.map) m.map.dispose(); m.dispose(); });\n",
+       "    }\n",
+       "  });\n",
+       "}\n",
+       "\n",
        "function buildScene() {\n",
+       "  disposeTree(root);\n",
        "  while (root.children.length) root.remove(root.children[0]);\n",
        "  groups = {}; pickables = [];\n",
        "  const Z = zScale;\n",
@@ -559,7 +573,9 @@
        "  box.setAttribute(&quot;style&quot;, &quot;margin-right:6px&quot;);\n",
        "  box.addEventListener(&quot;change&quot;, function () {\n",
        "    zScale = box.checked ? 4.0 : 1.0;\n",
-       "    buildScene();\n",
+       "    try { buildScene(); } catch (e) {\n",
+       "      fail(&quot;scene rebuild failed: &quot; + (e &amp;&amp; e.message ? e.message : e));\n",
+       "    }\n",
        "  });\n",
        "  row.appendChild(box);\n",
        "  row.appendChild(document.createTextNode(&quot;z ×4 (exaggerate thin layers)&quot;));\n",
@@ -629,10 +645,10 @@
    "id": "0c7386c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T03:38:19.102956Z",
-     "iopub.status.busy": "2026-07-20T03:38:19.102796Z",
-     "iopub.status.idle": "2026-07-20T03:38:19.105988Z",
-     "shell.execute_reply": "2026-07-20T03:38:19.105432Z"
+     "iopub.execute_input": "2026-07-21T07:26:13.140772Z",
+     "iopub.status.busy": "2026-07-21T07:26:13.140703Z",
+     "iopub.status.idle": "2026-07-21T07:26:13.143091Z",
+     "shell.execute_reply": "2026-07-21T07:26:13.142400Z"
     }
    },
    "outputs": [],

--- a/examples/05_fields_and_modes/05b_field_monitors.ipynb
+++ b/examples/05_fields_and_modes/05b_field_monitors.ipynb
@@ -30,24 +30,24 @@
    "id": "11d3cf06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T03:38:20.889543Z",
-     "iopub.status.busy": "2026-07-20T03:38:20.889438Z",
-     "iopub.status.idle": "2026-07-20T03:38:22.510961Z",
-     "shell.execute_reply": "2026-07-20T03:38:22.510224Z"
+     "iopub.execute_input": "2026-07-21T07:26:14.869595Z",
+     "iopub.status.busy": "2026-07-21T07:26:14.869451Z",
+     "iopub.status.idle": "2026-07-21T07:26:16.542373Z",
+     "shell.execute_reply": "2026-07-21T07:26:16.541839Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">20:38:21 PDT </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: Using canonical configuration directory at                </span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">00:26:15 PDT </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: Using canonical configuration directory at                </span>\n",
        "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span><span style=\"color: #008000; text-decoration-color: #008000\">'/home/mustafa/.config/tidy3d'</span><span style=\"color: #800000; text-decoration-color: #800000\">. Found legacy directory at          </span>\n",
        "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span><span style=\"color: #008000; text-decoration-color: #008000\">'~/.tidy3d'</span><span style=\"color: #800000; text-decoration-color: #800000\">, which will be ignored. Remove it manually or run      </span>\n",
        "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span><span style=\"color: #008000; text-decoration-color: #008000\">'tidy3d config migrate --delete-legacy'</span><span style=\"color: #800000; text-decoration-color: #800000\"> to clean up.               </span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m20:38:21 PDT\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: Using canonical configuration directory at                \u001b[0m\n",
+       "\u001b[2;36m00:26:15 PDT\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: Using canonical configuration directory at                \u001b[0m\n",
        "\u001b[2;36m             \u001b[0m\u001b[32m'/home/mustafa/.config/tidy3d'\u001b[0m\u001b[31m. Found legacy directory at          \u001b[0m\n",
        "\u001b[2;36m             \u001b[0m\u001b[32m'~/.tidy3d'\u001b[0m\u001b[31m, which will be ignored. Remove it manually or run      \u001b[0m\n",
        "\u001b[2;36m             \u001b[0m\u001b[32m'tidy3d config migrate --delete-legacy'\u001b[0m\u001b[31m to clean up.               \u001b[0m\n"
@@ -118,10 +118,10 @@
    "id": "d084a028",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T03:38:22.512519Z",
-     "iopub.status.busy": "2026-07-20T03:38:22.512306Z",
-     "iopub.status.idle": "2026-07-20T03:38:22.645847Z",
-     "shell.execute_reply": "2026-07-20T03:38:22.645084Z"
+     "iopub.execute_input": "2026-07-21T07:26:16.543383Z",
+     "iopub.status.busy": "2026-07-21T07:26:16.543182Z",
+     "iopub.status.idle": "2026-07-21T07:26:16.673424Z",
+     "shell.execute_reply": "2026-07-21T07:26:16.672819Z"
     }
    },
    "outputs": [
@@ -167,10 +167,10 @@
    "id": "7303475f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T03:38:22.647636Z",
-     "iopub.status.busy": "2026-07-20T03:38:22.647546Z",
-     "iopub.status.idle": "2026-07-20T03:38:22.755633Z",
-     "shell.execute_reply": "2026-07-20T03:38:22.754922Z"
+     "iopub.execute_input": "2026-07-21T07:26:16.674694Z",
+     "iopub.status.busy": "2026-07-21T07:26:16.674608Z",
+     "iopub.status.idle": "2026-07-21T07:26:16.777724Z",
+     "shell.execute_reply": "2026-07-21T07:26:16.777179Z"
     }
    },
    "outputs": [
@@ -217,19 +217,19 @@
    "id": "87edaf66",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T03:38:22.756802Z",
-     "iopub.status.busy": "2026-07-20T03:38:22.756714Z",
-     "iopub.status.idle": "2026-07-20T03:38:22.760185Z",
-     "shell.execute_reply": "2026-07-20T03:38:22.759815Z"
+     "iopub.execute_input": "2026-07-21T07:26:16.778794Z",
+     "iopub.status.busy": "2026-07-21T07:26:16.778712Z",
+     "iopub.status.idle": "2026-07-21T07:26:16.782077Z",
+     "shell.execute_reply": "2026-07-21T07:26:16.781792Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<iframe srcdoc=\"<div id=&quot;gdsfdtd3d_bdb3d5d6e5&quot; style=&quot;position:relative;width:100%;height:460px;background:#101418;border-radius:8px;overflow:hidden;font-family:system-ui,sans-serif&quot;>\n",
-       "  <div id=&quot;gdsfdtd3d_bdb3d5d6e5_info&quot; style=&quot;position:absolute;left:10px;top:10px;z-index:2;color:#dde3ea;font-size:12px;background:rgba(16,20,24,.75);padding:6px 10px;border-radius:6px;max-width:65%&quot;>si_sin_escalator — loading 3D viewer…</div>\n",
-       "  <div id=&quot;gdsfdtd3d_bdb3d5d6e5_legend&quot; style=&quot;position:absolute;right:10px;top:10px;z-index:2;color:#dde3ea;font-size:12px;background:rgba(16,20,24,.75);padding:6px 10px;border-radius:6px&quot;></div>\n",
+       "<iframe srcdoc=\"<div id=&quot;gdsfdtd3d_8215a3e64b&quot; style=&quot;position:relative;width:100%;height:460px;background:#101418;border-radius:8px;overflow:hidden;font-family:system-ui,sans-serif&quot;>\n",
+       "  <div id=&quot;gdsfdtd3d_8215a3e64b_info&quot; style=&quot;position:absolute;left:10px;top:10px;z-index:2;color:#dde3ea;font-size:12px;background:rgba(16,20,24,.75);padding:6px 10px;border-radius:6px;max-width:65%&quot;>loading 3D viewer…</div>\n",
+       "  <div id=&quot;gdsfdtd3d_8215a3e64b_legend&quot; style=&quot;position:absolute;right:10px;top:10px;z-index:2;color:#dde3ea;font-size:12px;background:rgba(16,20,24,.75);padding:6px 10px;border-radius:6px&quot;></div>\n",
        "</div>\n",
        "<script>\n",
        "(function () {\n",
@@ -273,9 +273,9 @@
        "}\n",
        "\n",
        "function start(attempt) {\n",
-       "var host = findEl(&quot;gdsfdtd3d_bdb3d5d6e5&quot;);\n",
-       "var info = findEl(&quot;gdsfdtd3d_bdb3d5d6e5_info&quot;);\n",
-       "var legendBox = findEl(&quot;gdsfdtd3d_bdb3d5d6e5_legend&quot;);\n",
+       "var host = findEl(&quot;gdsfdtd3d_8215a3e64b&quot;);\n",
+       "var info = findEl(&quot;gdsfdtd3d_8215a3e64b_info&quot;);\n",
+       "var legendBox = findEl(&quot;gdsfdtd3d_8215a3e64b_legend&quot;);\n",
        "if (!host || !info || !legendBox) {\n",
        "  if (attempt < 25) setTimeout(function () { start(attempt + 1); }, 120);\n",
        "  return;\n",
@@ -283,7 +283,8 @@
        "\n",
        "// boot stages are written into the panel: a failure names itself instead of\n",
        "// leaving a silent black rectangle\n",
-       "function stage(msg) { info.textContent = &quot;si_sin_escalator — &quot; + msg; }\n",
+       "// SCENE.name reaches the DOM only via textContent, which never parses HTML\n",
+       "function stage(msg) { info.textContent = (SCENE.name || &quot;component&quot;) + &quot; — &quot; + msg; }\n",
        "function fail(msg) {\n",
        "  info.textContent = &quot;3D viewer: &quot; + msg +\n",
        "    &quot; — use viewer3d.render_static for a static view.&quot;;\n",
@@ -379,7 +380,20 @@
        "const controls = new OrbitControls(camera, renderer.domElement);\n",
        "controls.enableDamping = true;\n",
        "\n",
+       "function disposeTree(obj) {\n",
+       "  // three.js does not free GPU memory on JS GC; release geometries, materials\n",
+       "  // and textures explicitly so repeated z-scale rebuilds do not leak VRAM\n",
+       "  obj.traverse(function (n) {\n",
+       "    if (n.geometry) n.geometry.dispose();\n",
+       "    if (n.material) {\n",
+       "      var mats = Array.isArray(n.material) ? n.material : [n.material];\n",
+       "      mats.forEach(function (m) { if (m.map) m.map.dispose(); m.dispose(); });\n",
+       "    }\n",
+       "  });\n",
+       "}\n",
+       "\n",
        "function buildScene() {\n",
+       "  disposeTree(root);\n",
        "  while (root.children.length) root.remove(root.children[0]);\n",
        "  groups = {}; pickables = [];\n",
        "  const Z = zScale;\n",
@@ -520,7 +534,9 @@
        "  box.setAttribute(&quot;style&quot;, &quot;margin-right:6px&quot;);\n",
        "  box.addEventListener(&quot;change&quot;, function () {\n",
        "    zScale = box.checked ? 4.0 : 1.0;\n",
-       "    buildScene();\n",
+       "    try { buildScene(); } catch (e) {\n",
+       "      fail(&quot;scene rebuild failed: &quot; + (e &amp;&amp; e.message ? e.message : e));\n",
+       "    }\n",
        "  });\n",
        "  row.appendChild(box);\n",
        "  row.appendChild(document.createTextNode(&quot;z ×4 (exaggerate thin layers)&quot;));\n",
@@ -606,10 +622,10 @@
    "id": "66f1bfd5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T03:38:22.761153Z",
-     "iopub.status.busy": "2026-07-20T03:38:22.761025Z",
-     "iopub.status.idle": "2026-07-20T03:38:22.838169Z",
-     "shell.execute_reply": "2026-07-20T03:38:22.837581Z"
+     "iopub.execute_input": "2026-07-21T07:26:16.783408Z",
+     "iopub.status.busy": "2026-07-21T07:26:16.783321Z",
+     "iopub.status.idle": "2026-07-21T07:26:16.854481Z",
+     "shell.execute_reply": "2026-07-21T07:26:16.853862Z"
     }
    },
    "outputs": [
@@ -655,10 +671,10 @@
    "id": "51708204",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T03:38:22.840069Z",
-     "iopub.status.busy": "2026-07-20T03:38:22.839881Z",
-     "iopub.status.idle": "2026-07-20T03:38:22.927350Z",
-     "shell.execute_reply": "2026-07-20T03:38:22.926923Z"
+     "iopub.execute_input": "2026-07-21T07:26:16.855498Z",
+     "iopub.status.busy": "2026-07-21T07:26:16.855413Z",
+     "iopub.status.idle": "2026-07-21T07:26:16.931180Z",
+     "shell.execute_reply": "2026-07-21T07:26:16.930713Z"
     }
    },
    "outputs": [
@@ -701,10 +717,10 @@
    "id": "5c518d9f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T03:38:22.929068Z",
-     "iopub.status.busy": "2026-07-20T03:38:22.928857Z",
-     "iopub.status.idle": "2026-07-20T03:38:22.935065Z",
-     "shell.execute_reply": "2026-07-20T03:38:22.934339Z"
+     "iopub.execute_input": "2026-07-21T07:26:16.932553Z",
+     "iopub.status.busy": "2026-07-21T07:26:16.932468Z",
+     "iopub.status.idle": "2026-07-21T07:26:16.936538Z",
+     "shell.execute_reply": "2026-07-21T07:26:16.936083Z"
     }
    },
    "outputs": [

--- a/examples/11_bragg_grating/11_bragg_grating.ipynb
+++ b/examples/11_bragg_grating/11_bragg_grating.ipynb
@@ -30,24 +30,24 @@
    "id": "1341a580",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T03:38:24.729617Z",
-     "iopub.status.busy": "2026-07-20T03:38:24.729533Z",
-     "iopub.status.idle": "2026-07-20T03:38:26.511223Z",
-     "shell.execute_reply": "2026-07-20T03:38:26.510680Z"
+     "iopub.execute_input": "2026-07-21T07:26:18.602205Z",
+     "iopub.status.busy": "2026-07-21T07:26:18.601995Z",
+     "iopub.status.idle": "2026-07-21T07:26:20.367000Z",
+     "shell.execute_reply": "2026-07-21T07:26:20.366212Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">20:38:25 PDT </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: Using canonical configuration directory at                </span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">00:26:19 PDT </span><span style=\"color: #800000; text-decoration-color: #800000\">WARNING: Using canonical configuration directory at                </span>\n",
        "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span><span style=\"color: #008000; text-decoration-color: #008000\">'/home/mustafa/.config/tidy3d'</span><span style=\"color: #800000; text-decoration-color: #800000\">. Found legacy directory at          </span>\n",
        "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span><span style=\"color: #008000; text-decoration-color: #008000\">'~/.tidy3d'</span><span style=\"color: #800000; text-decoration-color: #800000\">, which will be ignored. Remove it manually or run      </span>\n",
        "<span style=\"color: #7fbfbf; text-decoration-color: #7fbfbf\">             </span><span style=\"color: #008000; text-decoration-color: #008000\">'tidy3d config migrate --delete-legacy'</span><span style=\"color: #800000; text-decoration-color: #800000\"> to clean up.               </span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "\u001b[2;36m20:38:25 PDT\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: Using canonical configuration directory at                \u001b[0m\n",
+       "\u001b[2;36m00:26:19 PDT\u001b[0m\u001b[2;36m \u001b[0m\u001b[31mWARNING: Using canonical configuration directory at                \u001b[0m\n",
        "\u001b[2;36m             \u001b[0m\u001b[32m'/home/mustafa/.config/tidy3d'\u001b[0m\u001b[31m. Found legacy directory at          \u001b[0m\n",
        "\u001b[2;36m             \u001b[0m\u001b[32m'~/.tidy3d'\u001b[0m\u001b[31m, which will be ignored. Remove it manually or run      \u001b[0m\n",
        "\u001b[2;36m             \u001b[0m\u001b[32m'tidy3d config migrate --delete-legacy'\u001b[0m\u001b[31m to clean up.               \u001b[0m\n"
@@ -128,10 +128,10 @@
    "id": "86b5eae9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T03:38:26.513206Z",
-     "iopub.status.busy": "2026-07-20T03:38:26.512739Z",
-     "iopub.status.idle": "2026-07-20T03:38:26.597341Z",
-     "shell.execute_reply": "2026-07-20T03:38:26.597041Z"
+     "iopub.execute_input": "2026-07-21T07:26:20.369078Z",
+     "iopub.status.busy": "2026-07-21T07:26:20.368663Z",
+     "iopub.status.idle": "2026-07-21T07:26:20.447817Z",
+     "shell.execute_reply": "2026-07-21T07:26:20.447031Z"
     }
    },
    "outputs": [
@@ -176,10 +176,10 @@
    "id": "86b1ace5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T03:38:26.598979Z",
-     "iopub.status.busy": "2026-07-20T03:38:26.598897Z",
-     "iopub.status.idle": "2026-07-20T03:38:26.718921Z",
-     "shell.execute_reply": "2026-07-20T03:38:26.718369Z"
+     "iopub.execute_input": "2026-07-21T07:26:20.450082Z",
+     "iopub.status.busy": "2026-07-21T07:26:20.449970Z",
+     "iopub.status.idle": "2026-07-21T07:26:20.568195Z",
+     "shell.execute_reply": "2026-07-21T07:26:20.567790Z"
     }
    },
    "outputs": [
@@ -223,19 +223,19 @@
    "id": "fda18f6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T03:38:26.720448Z",
-     "iopub.status.busy": "2026-07-20T03:38:26.720295Z",
-     "iopub.status.idle": "2026-07-20T03:38:26.727700Z",
-     "shell.execute_reply": "2026-07-20T03:38:26.727289Z"
+     "iopub.execute_input": "2026-07-21T07:26:20.570697Z",
+     "iopub.status.busy": "2026-07-21T07:26:20.570488Z",
+     "iopub.status.idle": "2026-07-21T07:26:20.579105Z",
+     "shell.execute_reply": "2026-07-21T07:26:20.578710Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<iframe srcdoc=\"<div id=&quot;gdsfdtd3d_bbce443104&quot; style=&quot;position:relative;width:100%;height:440px;background:#101418;border-radius:8px;overflow:hidden;font-family:system-ui,sans-serif&quot;>\n",
-       "  <div id=&quot;gdsfdtd3d_bbce443104_info&quot; style=&quot;position:absolute;left:10px;top:10px;z-index:2;color:#dde3ea;font-size:12px;background:rgba(16,20,24,.75);padding:6px 10px;border-radius:6px;max-width:65%&quot;>bragg_te1550 — loading 3D viewer…</div>\n",
-       "  <div id=&quot;gdsfdtd3d_bbce443104_legend&quot; style=&quot;position:absolute;right:10px;top:10px;z-index:2;color:#dde3ea;font-size:12px;background:rgba(16,20,24,.75);padding:6px 10px;border-radius:6px&quot;></div>\n",
+       "<iframe srcdoc=\"<div id=&quot;gdsfdtd3d_01323f1760&quot; style=&quot;position:relative;width:100%;height:440px;background:#101418;border-radius:8px;overflow:hidden;font-family:system-ui,sans-serif&quot;>\n",
+       "  <div id=&quot;gdsfdtd3d_01323f1760_info&quot; style=&quot;position:absolute;left:10px;top:10px;z-index:2;color:#dde3ea;font-size:12px;background:rgba(16,20,24,.75);padding:6px 10px;border-radius:6px;max-width:65%&quot;>loading 3D viewer…</div>\n",
+       "  <div id=&quot;gdsfdtd3d_01323f1760_legend&quot; style=&quot;position:absolute;right:10px;top:10px;z-index:2;color:#dde3ea;font-size:12px;background:rgba(16,20,24,.75);padding:6px 10px;border-radius:6px&quot;></div>\n",
        "</div>\n",
        "<script>\n",
        "(function () {\n",
@@ -279,9 +279,9 @@
        "}\n",
        "\n",
        "function start(attempt) {\n",
-       "var host = findEl(&quot;gdsfdtd3d_bbce443104&quot;);\n",
-       "var info = findEl(&quot;gdsfdtd3d_bbce443104_info&quot;);\n",
-       "var legendBox = findEl(&quot;gdsfdtd3d_bbce443104_legend&quot;);\n",
+       "var host = findEl(&quot;gdsfdtd3d_01323f1760&quot;);\n",
+       "var info = findEl(&quot;gdsfdtd3d_01323f1760_info&quot;);\n",
+       "var legendBox = findEl(&quot;gdsfdtd3d_01323f1760_legend&quot;);\n",
        "if (!host || !info || !legendBox) {\n",
        "  if (attempt < 25) setTimeout(function () { start(attempt + 1); }, 120);\n",
        "  return;\n",
@@ -289,7 +289,8 @@
        "\n",
        "// boot stages are written into the panel: a failure names itself instead of\n",
        "// leaving a silent black rectangle\n",
-       "function stage(msg) { info.textContent = &quot;bragg_te1550 — &quot; + msg; }\n",
+       "// SCENE.name reaches the DOM only via textContent, which never parses HTML\n",
+       "function stage(msg) { info.textContent = (SCENE.name || &quot;component&quot;) + &quot; — &quot; + msg; }\n",
        "function fail(msg) {\n",
        "  info.textContent = &quot;3D viewer: &quot; + msg +\n",
        "    &quot; — use viewer3d.render_static for a static view.&quot;;\n",
@@ -385,7 +386,20 @@
        "const controls = new OrbitControls(camera, renderer.domElement);\n",
        "controls.enableDamping = true;\n",
        "\n",
+       "function disposeTree(obj) {\n",
+       "  // three.js does not free GPU memory on JS GC; release geometries, materials\n",
+       "  // and textures explicitly so repeated z-scale rebuilds do not leak VRAM\n",
+       "  obj.traverse(function (n) {\n",
+       "    if (n.geometry) n.geometry.dispose();\n",
+       "    if (n.material) {\n",
+       "      var mats = Array.isArray(n.material) ? n.material : [n.material];\n",
+       "      mats.forEach(function (m) { if (m.map) m.map.dispose(); m.dispose(); });\n",
+       "    }\n",
+       "  });\n",
+       "}\n",
+       "\n",
        "function buildScene() {\n",
+       "  disposeTree(root);\n",
        "  while (root.children.length) root.remove(root.children[0]);\n",
        "  groups = {}; pickables = [];\n",
        "  const Z = zScale;\n",
@@ -526,7 +540,9 @@
        "  box.setAttribute(&quot;style&quot;, &quot;margin-right:6px&quot;);\n",
        "  box.addEventListener(&quot;change&quot;, function () {\n",
        "    zScale = box.checked ? 4.0 : 1.0;\n",
-       "    buildScene();\n",
+       "    try { buildScene(); } catch (e) {\n",
+       "      fail(&quot;scene rebuild failed: &quot; + (e &amp;&amp; e.message ? e.message : e));\n",
+       "    }\n",
        "  });\n",
        "  row.appendChild(box);\n",
        "  row.appendChild(document.createTextNode(&quot;z ×4 (exaggerate thin layers)&quot;));\n",
@@ -608,10 +624,10 @@
    "id": "37de76b7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T03:38:26.728644Z",
-     "iopub.status.busy": "2026-07-20T03:38:26.728578Z",
-     "iopub.status.idle": "2026-07-20T03:38:26.799194Z",
-     "shell.execute_reply": "2026-07-20T03:38:26.798488Z"
+     "iopub.execute_input": "2026-07-21T07:26:20.581192Z",
+     "iopub.status.busy": "2026-07-21T07:26:20.581122Z",
+     "iopub.status.idle": "2026-07-21T07:26:20.649860Z",
+     "shell.execute_reply": "2026-07-21T07:26:20.649185Z"
     }
    },
    "outputs": [
@@ -688,10 +704,10 @@
    "id": "efdedc6b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T03:38:26.800896Z",
-     "iopub.status.busy": "2026-07-20T03:38:26.800793Z",
-     "iopub.status.idle": "2026-07-20T03:38:27.013788Z",
-     "shell.execute_reply": "2026-07-20T03:38:27.013402Z"
+     "iopub.execute_input": "2026-07-21T07:26:20.652572Z",
+     "iopub.status.busy": "2026-07-21T07:26:20.652400Z",
+     "iopub.status.idle": "2026-07-21T07:26:20.866278Z",
+     "shell.execute_reply": "2026-07-21T07:26:20.865682Z"
     }
    },
    "outputs": [
@@ -750,10 +766,10 @@
    "id": "3cd1d574",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-20T03:38:27.015293Z",
-     "iopub.status.busy": "2026-07-20T03:38:27.015213Z",
-     "iopub.status.idle": "2026-07-20T03:38:27.056294Z",
-     "shell.execute_reply": "2026-07-20T03:38:27.055687Z"
+     "iopub.execute_input": "2026-07-21T07:26:20.867593Z",
+     "iopub.status.busy": "2026-07-21T07:26:20.867488Z",
+     "iopub.status.idle": "2026-07-21T07:26:20.908035Z",
+     "shell.execute_reply": "2026-07-21T07:26:20.907725Z"
     }
    },
    "outputs": [

--- a/src/gds_fdtd/plotting.py
+++ b/src/gds_fdtd/plotting.py
@@ -775,7 +775,12 @@ def component_outlines(component: Any, axis: str = "z", buffer: float | None = N
         for p in component.ports:
             try:
                 ext = np.asarray(p.polygon_extension(buffer=float(buffer)), dtype=float)
-            except Exception:  # a port without geometry info cannot extend
+            except (
+                AttributeError,
+                ValueError,
+                TypeError,
+                IndexError,
+            ):  # a port without geometry info cannot extend
                 continue
             if ext.ndim != 2 or len(ext) < 3:
                 continue
@@ -837,7 +842,7 @@ def plot_monitor_planes(solver: Any, savefig: str | None = None) -> tuple[Any, A
     for p in comp.ports:
         try:
             ext = np.asarray(p.polygon_extension(buffer=2 * spec.buffer), dtype=float)
-        except Exception:
+        except (AttributeError, ValueError, TypeError, IndexError):
             ext = None
         if ext is not None and ext.ndim == 2 and len(ext) >= 3:
             closed = np.vstack([ext, ext[:1]])

--- a/src/gds_fdtd/viewer3d.py
+++ b/src/gds_fdtd/viewer3d.py
@@ -120,7 +120,12 @@ def _port_extension_objects(
     for p in component.ports:
         try:
             contour = np.asarray(p.polygon_extension(buffer=buffer), dtype=float)
-        except Exception:  # a port without geometry info cannot extend
+        except (
+            AttributeError,
+            ValueError,
+            TypeError,
+            IndexError,
+        ):  # a port without geometry info cannot extend
             continue
         if contour.ndim != 2 or len(contour) < 3:
             continue
@@ -257,7 +262,7 @@ background:#101418;border-radius:8px;overflow:hidden;\
 font-family:system-ui,sans-serif">
   <div id="__ID___info" style="position:absolute;left:10px;top:10px;z-index:2;\
 color:#dde3ea;font-size:12px;background:rgba(16,20,24,.75);padding:6px 10px;\
-border-radius:6px;max-width:65%">__NAME__ — loading 3D viewer…</div>
+border-radius:6px;max-width:65%">loading 3D viewer…</div>
   <div id="__ID___legend" style="position:absolute;right:10px;top:10px;z-index:2;\
 color:#dde3ea;font-size:12px;background:rgba(16,20,24,.75);padding:6px 10px;\
 border-radius:6px"></div>
@@ -314,7 +319,8 @@ if (!host || !info || !legendBox) {
 
 // boot stages are written into the panel: a failure names itself instead of
 // leaving a silent black rectangle
-function stage(msg) { info.textContent = "__NAME__ — " + msg; }
+// SCENE.name reaches the DOM only via textContent, which never parses HTML
+function stage(msg) { info.textContent = (SCENE.name || "component") + " — " + msg; }
 function fail(msg) {
   info.textContent = "3D viewer: " + msg +
     " — use viewer3d.render_static for a static view.";
@@ -410,7 +416,20 @@ function makeLabel(txt) {
 const controls = new OrbitControls(camera, renderer.domElement);
 controls.enableDamping = true;
 
+function disposeTree(obj) {
+  // three.js does not free GPU memory on JS GC; release geometries, materials
+  // and textures explicitly so repeated z-scale rebuilds do not leak VRAM
+  obj.traverse(function (n) {
+    if (n.geometry) n.geometry.dispose();
+    if (n.material) {
+      var mats = Array.isArray(n.material) ? n.material : [n.material];
+      mats.forEach(function (m) { if (m.map) m.map.dispose(); m.dispose(); });
+    }
+  });
+}
+
 function buildScene() {
+  disposeTree(root);
   while (root.children.length) root.remove(root.children[0]);
   groups = {}; pickables = [];
   const Z = zScale;
@@ -551,7 +570,9 @@ for (const g of Object.keys(groups)) {
   box.setAttribute("style", "margin-right:6px");
   box.addEventListener("change", function () {
     zScale = box.checked ? 4.0 : 1.0;
-    buildScene();
+    try { buildScene(); } catch (e) {
+      fail("scene rebuild failed: " + (e && e.message ? e.message : e));
+    }
   });
   row.appendChild(box);
   row.appendChild(document.createTextNode("z ×4 (exaggerate thin layers)"));
@@ -609,12 +630,27 @@ def scene_html(scene: dict[str, Any], height: int = 520) -> str:
     # committed output and the freshly-run one side by side, and a content-
     # derived id would make the script attach its canvas to the stale copy
     uid = f"gdsfdtd3d_{uuid.uuid4().hex[:10]}"
+    # Escape the scene JSON for a <script> context: user-derived strings
+    # (component/structure/port names, materials — sourced from arbitrary GDS
+    # files) must not be able to close the script element or inject markup.
+    # <, >, & become \u.... escapes json.loads reads back unchanged, so the
+    # JS still parses the real characters; U+2028/U+2029 are JSON-legal but
+    # were JS line terminators before ES2019. The name reaches the DOM only
+    # through SCENE.name via textContent (never parsed as HTML), so there is
+    # no separate __NAME__ substitution to escape.
+    scene_json = (
+        json.dumps(scene)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+        .replace("\u2028", "\\u2028")
+        .replace("\u2029", "\\u2029")
+    )
     return (
         _HTML_TEMPLATE.replace("__ID__", uid)
         .replace("__HEIGHT__", str(int(height)))
-        .replace("__NAME__", str(scene.get("name", "component")))
         .replace("__THREE__", _THREE_VERSION)
-        .replace("__SCENE_JSON__", json.dumps(scene))
+        .replace("__SCENE_JSON__", scene_json)
     )
 
 

--- a/tests/test_viewer3d.py
+++ b/tests/test_viewer3d.py
@@ -152,3 +152,56 @@ def test_scene_skips_degenerate_polygons(escalator_solver):
     objects2, _, _ = _structure_objects(comp2)
     assert len(objects2) == n_before + 1 or len(objects2) == n_before  # bad one skipped
     assert all(len(np.asarray(o["contour"])) >= 3 for o in objects2)
+
+
+def test_scene_html_escapes_hostile_names():
+    """User-derived GDS names must not break out of the <script> block or the
+    srcdoc document (component/structure/port names come from arbitrary files;
+    save_3d output gets shared)."""
+    evil = '</script><img src=x onerror="window.__P=1"><div id="M">Z</div>'
+    scene = {
+        "name": evil,
+        "objects": [
+            {
+                "kind": "structure",
+                "group": "layers",
+                "name": evil,
+                "info": "mat & <stuff>",
+                "contour": [[0, 0], [1, 0], [1, 1]],
+                "z0": 0.0,
+                "z1": 0.22,
+                "color": "#b2182b",
+                "opacity": 1.0,
+            }
+        ],
+        "legend": {"layer 1/0": "#b2182b"},
+        "frame": {"center": [0.5, 0.5, 0.11], "span": [1, 1, 0.22]},
+    }
+    html = scene_html(scene, height=300)
+    # the raw injection payload never appears verbatim; < is <-escaped
+    assert "<img src=x" not in html
+    assert 'onerror="window.__P=1"' not in html
+    assert "\\u003c" in html
+    # exactly one real </script> (the template's own close), none injected
+    assert html.count("</script>") == 1
+    # __NAME__ is never substituted raw anymore
+    assert "__NAME__" not in html
+    # the JSON still decodes back to the ORIGINAL characters for the viewer
+    start = html.index("var SCENE = ") + len("var SCENE = ")
+    end = html.index(";\n", start)
+    recovered = json.loads(html[start:end])
+    assert recovered["name"] == evil
+    assert recovered["objects"][0]["name"] == evil
+
+
+def test_scene_html_plain_scene_unescaped():
+    """Escaping is a no-op for ordinary names (no false churn / no broken JSON)."""
+    scene = {
+        "name": "escalator",
+        "objects": [],
+        "legend": {},
+        "frame": {"center": [0, 0, 0], "span": [1, 1, 1]},
+    }
+    html = scene_html(scene, height=200)
+    assert "\\u003c" not in html
+    assert "disposeTree" in html  # GPU cleanup on z-scale rebuild is present


### PR DESCRIPTION
Release prep for **v0.6.1**. I ran a multi-agent review of `v0.6.0..HEAD` (40 commits) covering Python-source correctness, the new `viewer3d` module + its embedded JS, and docs/changelog/figures. The Python source came back clean; the viewer review surfaced a **security issue**, which this PR fixes, then completes the changelog and docs.

## Security — viewer HTML/JS injection (fixed)
Component, structure, and port names (and material labels) come from **arbitrary GDS files** and were substituted verbatim into the viewer's `<script>` block and info panel. A name containing `</script>` or markup could inject executable HTML/JS — a real risk for shared `save_3d` output, and a plain robustness bug for any legitimately special-character name.

Fix: the scene JSON is now `\uXXXX`-escaped for the script context (`<`, `>`, `&`, U+2028/U+2029, all valid JSON escapes `json.loads` reads back unchanged), and the component name reaches the DOM only via `textContent` (never parsed as HTML) — the raw `__NAME__` template substitution is gone; the JS reads `SCENE.name`.

**Verified** with a headless-browser probe: `getElementById(<injected id>)` is `null` and the injected global is `undefined`. Two regression tests added.

## Viewer robustness (same review)
- `buildScene()` disposes GPU geometries/materials/textures before each z-scale rebuild — repeated "z ×4" toggles no longer leak VRAM.
- the toggle rebuild is wrapped `try/catch → fail()`, so an error names itself in the panel instead of a silent black rectangle.

## Plotting
- narrowed the broad `except Exception` around `polygon_extension` (in `component_outlines`, `plot_monitor_planes`, `_port_extension_objects`) to `(AttributeError, ValueError, TypeError, IndexError)` so genuine bugs surface instead of silently dropping a port.

## Docs / changelog
- `CHANGELOG [Unreleased] → [0.6.1]` with the previously-missing entries: the Security fix, the subprocess job-log fix, the viewer render-portability + static-aspect fixes, the true-1:1 default + z×4 toggle, the `sphinx-rtd-theme` removal, and the dependency-floor + CI-action sweep.
- `simulations.rst` documents the true-aspect default, the z×4 toggle, and the port mode planes, and wires in the (previously orphaned) `escalator_3d.png` as the `render_static` example figure.
- README release example → `v0.6.1`; `HANDOFF.md` / `ROADMAP.md` refreshed to 0.6.1.

The three viewer notebooks (01, 05b, 11) were re-executed so their committed outputs carry the hardened template.

Gates: `ruff` + `ruff format` + `mypy --strict` clean, **90.22%** branch coverage, `sphinx-build` clean. After this merges I'll tag `v0.6.1`.

_Note: strict semver would make the new-feature content a minor (0.7.0), but the project is in `0.x` initial-development and 0.6.1 was the requested version — flagging for awareness._
