### PR TITLE
build: cap beamz below 0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Cap the optional beamz dependency below 0.5 until the adapter is migrated to
+  beamz's backward-incompatible 0.5 API (#85).
+
 ## [0.6.1] - 2026-07-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ show_3d(solver)   # notebooks + docs; save_3d(...) writes a shareable page
 |---|---|---|---|
 | [Tidy3D](https://github.com/flexcompute/tidy3d) >= 2.11 | cloud | FlexCredits | `pip install gds_fdtd[tidy3d]` |
 | Ansys Lumerical FDTD 2024/2025 | local | license | Lumerical install + `lumapi` on path |
-| [beamz](https://github.com/beamzorg/beamz) >= 0.4 | local (JAX, CPU/GPU) | free | `pip install gds_fdtd[beamz]` |
+| [beamz](https://github.com/beamzorg/beamz) >= 0.4.3, < 0.5 | local (JAX, CPU/GPU) | free | `pip install gds_fdtd[beamz]` |
 
 ## Examples
 

--- a/docs/solvers.rst
+++ b/docs/solvers.rst
@@ -63,7 +63,7 @@ Available engines
      - local
      - license
      - Lumerical install with ``lumapi`` on path
-   * - `beamz <https://github.com/beamzorg/beamz>`_ >= 0.4
+   * - `beamz <https://github.com/beamzorg/beamz>`_ >= 0.4.3, < 0.5
      - local (JAX CPU/GPU)
      - free
      - ``pip install gds_fdtd[beamz]``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ gds-fdtd = "gds_fdtd.cli:main"
 
 tidy3d      = ["tidy3d>=2.11,<3"]              # enables gds_fdtd.solver_tidy3d (2.8.x is numpy<2/py<=3.12 only; F5)
 gdsfactory  = ["gdsfactory>=9.5.7,<10"]
-beamz       = ["beamz>=0.4.3"]                 # open-source JAX FDTD engine
+beamz       = ["beamz>=0.4.3,<0.5"]            # open-source JAX FDTD engine
 prefab      = ["prefab>=1.2.0"]
 siepic      = ["SiEPIC>=0.5.31"]
 fuzz        = ["atheris>=3.1.0"]                 # run fuzz/ targets locally (CI uses ClusterFuzzLite)

--- a/src/gds_fdtd/solvers/beamz.py
+++ b/src/gds_fdtd/solvers/beamz.py
@@ -1,7 +1,7 @@
 """
 gds_fdtd simulation toolbox.
 
-BeamzSolver: the beamz (>= 0.4) adapter on the Phase-3 Solver contract. beamz
+BeamzSolver: the beamz (>= 0.4.3, < 0.5) adapter on the Phase-3 Solver contract. beamz
 is an open-source JAX FDTD engine (Apache-2.0, pip-installable, CPU or GPU) —
 the first zero-cost engine in the registry.
 

--- a/uv.lock
+++ b/uv.lock
@@ -908,9 +908,9 @@ tidy3d = [
 [package.metadata]
 requires-dist = [
     { name = "atheris", marker = "extra == 'fuzz'", specifier = ">=3.1.0" },
-    { name = "beamz", marker = "extra == 'all'", specifier = ">=0.4.3" },
-    { name = "beamz", marker = "extra == 'beamz'", specifier = ">=0.4.3" },
-    { name = "beamz", marker = "extra == 'engines'", specifier = ">=0.4.3" },
+    { name = "beamz", marker = "extra == 'all'", specifier = ">=0.4.3,<0.5" },
+    { name = "beamz", marker = "extra == 'beamz'", specifier = ">=0.4.3,<0.5" },
+    { name = "beamz", marker = "extra == 'engines'", specifier = ">=0.4.3,<0.5" },
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "codespell", marker = "extra == 'dev'", specifier = ">=2.4.3" },
     { name = "coverage", marker = "extra == 'dev'" },


### PR DESCRIPTION
## What

Prevent the optional solver extra from resolving the upcoming backward-incompatible BeamZ 0.5 API. Keep the package metadata, lockfile, and compatibility docs aligned.

Fixes #85


## Validation

<!-- How was this verified? Paste the relevant command + result. -->

- [ ] `uv run pytest tests` passes locally (paste the exit line, not `| tail`)
- [ ] `uv run ruff check . && uv run ruff format --check . && uv run codespell src tests` clean
- [ ] New behavior has a test that fails without the change
- [ ] No `cloud`/`licensed` test runs in CI paths (marker taxonomy respected)

## Cost
None.
