### PR TITLE
ci(security): scope pip-audit exceptions for the unremediable cryptography CVEs

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,9 +28,24 @@ jobs:
         with:
           python-version: "3.13"
       - name: Audit locked dependency tree
+        # Scoped exceptions, reviewed individually - NOT a blanket mute. Each id
+        # is listed with the reason it cannot be remediated downstream; drop the
+        # flag as soon as upstream moves. Tracking issue: #115.
+        #
+        # CVE-2026-69247/69248/69249 (cryptography < 50.0.0 / < 49.0.0):
+        #   tidy3d 2.12.0 hard-pins `cryptography==48.0.1` (an exact pin it
+        #   applies on Intel macOS), so no resolution of this lock can satisfy
+        #   the fixed versions while the tidy3d extra is present - verified with
+        #   `uv lock` under a `cryptography>=50` constraint, which reports the
+        #   requirements as unsatisfiable. The affected code path is authlib's
+        #   JWT handling inside the fastmcp server that tidy3d vendors; gds_fdtd
+        #   never exercises it (we use tidy3d's `web` upload/download API).
         run: |
           uv export --locked --all-extras --format requirements-txt --no-emit-project -o requirements-audit.txt
-          uvx pip-audit --strict -r requirements-audit.txt
+          uvx pip-audit --strict -r requirements-audit.txt \
+            --ignore-vuln CVE-2026-69247 \
+            --ignore-vuln CVE-2026-69248 \
+            --ignore-vuln CVE-2026-69249
 
   dependency-review:
     name: dependency review (PR diff)


### PR DESCRIPTION
`pip-audit` started failing on every PR today against three fresh advisories in `cryptography` 48.0.1 — `CVE-2026-69247` (fixed in 50.0.0), `CVE-2026-69248` and `CVE-2026-69249` (fixed in 49.0.0). This unblocks CI without pretending the finding does not exist.

**Why we cannot simply upgrade.** `tidy3d` 2.12.0 declares an exact pin:

```
cryptography==48.0.1; platform_system == "Darwin" and platform_machine == "x86_64"
```

(2.11.2 had no cryptography constraint — this arrived with 2.12.0.) Adding `[tool.uv] constraint-dependencies = ["cryptography>=50.0.0"]` and re-locking reports the requirements as **unsatisfiable**, and 2.12.0 is the newest tidy3d available. Upstream scopes the pin to Intel macOS, but uv's unified resolution propagates it to the whole non-Windows marker group, so `uv sync --locked` picks it up on Linux too.

**What this does.** Passes `--ignore-vuln` for exactly those three ids, with the reasoning inline in the workflow and exit criteria tracked in #115. It is deliberately narrow: any other advisory — including a future cryptography one — still fails the job. Leaving it permanently red was the worse option, since that is how real findings get missed.

**Exposure.** The affected code is authlib's JWT/JOSE handling, reached via `tidy3d -> fastmcp -> authlib`. gds_fdtd does not use tidy3d's bundled MCP server; we use its `web` upload/download API, so the vulnerable path sits in the tree unexercised.

**The alternative, for the record:** capping `tidy3d < 2.12` restores a fully clean audit (2.11.2 pulls no pin, so cryptography resolves to 50.x) at the cost of holding users on 2.11.2 — which is also the version `SOLVER_STATUS.md` records as live-validated. That is a one-line change and the right call if these turn out to be severe; OSV had published no severity metadata at the time of writing, so I did not want to restrict the flagship engine on an unknown.
