### PR TITLE
release: v0.6.2 - dependency maintenance, beamz cap, documented audit exception

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,9 +37,12 @@ jobs:
         #   applies on Intel macOS), so no resolution of this lock can satisfy
         #   the fixed versions while the tidy3d extra is present - verified with
         #   `uv lock` under a `cryptography>=50` constraint, which reports the
-        #   requirements as unsatisfiable. The affected code path is authlib's
-        #   JWT handling inside the fastmcp server that tidy3d vendors; gds_fdtd
-        #   never exercises it (we use tidy3d's `web` upload/download API).
+        #   requirements as unsatisfiable.
+        #   Not reachable here: the defect is a Bleichenbacher oracle in PKCS#7
+        #   EnvelopedData decryption (cryptography...serialization.pkcs7).
+        #   Checked rather than assumed - authlib 1.7.2 and tidy3d 2.12.0 each
+        #   contain zero references to that API (authlib imports only the
+        #   asymmetric/JOSE primitives), and gds_fdtd never imports cryptography.
         run: |
           uv export --locked --all-extras --format requirements-txt --no-emit-project -o requirements-audit.txt
           uvx pip-audit --strict -r requirements-audit.txt \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-08-04
+
+Maintenance release: dependency floors, a protective cap on beamz, and a
+documented security exception. No API changes and no behavioural changes to
+the package itself — code written against 0.6.1 keeps working.
+
 ### Changed
 - Cap the optional beamz dependency below 0.5 until the adapter is migrated to
   beamz's backward-incompatible 0.5 API (#85).
+- Dependency floors raised to current releases, with `uv.lock` re-synced:
+  - runtime: klayout ≥ 0.30.10, matplotlib ≥ 3.11.1, PyYAML ≥ 6.0.3
+  - extras: tidy3d ≥ 2.12.0 (still `<3`), gdsfactory ≥ 9.45.0 (still `<10`),
+    prefab ≥ 1.6.0
+  - dev: pytest ≥ 9.1.1, pytest-cov ≥ 7.1.0, ruff ≥ 0.16.1,
+    hypothesis ≥ 6.164.0, h5py ≥ 3.16.0, build ≥ 1.5.0, pip ≥ 26.2
+  - docs: myst-nb ≥ 1.4.0, furo ≥ 2025.12.19
+- Pinned GitHub Actions bumped to current releases (setup-uv v9,
+  download-artifact v8, build-and-inspect-python-package v3, prek-action v3,
+  sigstore-python 3.5.0, checkout, codeql-action, scorecard, pypi-publish).
+  The two majors on the release path were checked against how we use them:
+  `build-and-inspect` v3 keeps an identical `Packages` artifact contract, and
+  the actions dropping floating `@vN` tags are unaffected here because every
+  action is pinned by commit SHA.
+
+### Security
+- `pip-audit` reports three advisories against `cryptography` 48.0.1 —
+  **CVE-2026-69247** (high; a Bleichenbacher oracle in PKCS#7 EnvelopedData
+  decryption), CVE-2026-69248 and CVE-2026-69249. They cannot be remediated
+  downstream: tidy3d 2.12.0 declares an exact `cryptography==48.0.1` pin, and
+  re-locking under a `cryptography>=50` constraint reports the requirements as
+  unsatisfiable.
+  The vulnerable API is not reachable from this package — authlib 1.7.2 and
+  tidy3d 2.12.0 each contain zero references to `serialization.pkcs7`, and
+  gds_fdtd never imports `cryptography` at all — so the three ids are ignored
+  explicitly in the security workflow, with the reasoning inline and exit
+  criteria tracked in #115. Every other advisory still fails that job.
+  Capping `tidy3d < 2.12` remains a one-line alternative that restores a fully
+  clean audit at the cost of holding users on 2.11.2.
 
 ## [0.6.1] - 2026-07-21
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -6,7 +6,9 @@ the compressed history and the working conventions; the live plan is
 [`SOLVER_STATUS.md`](SOLVER_STATUS.md), and user-facing docs live at
 <https://siepic.github.io/gds_fdtd/>.
 
-**State:** `v0.6.1` is released (tagged 2026-07-21, signed GitHub release).
+**State:** `v0.6.2` is released (tagged 2026-08-04, signed GitHub release) — a
+maintenance release over `v0.6.1` (dependency floors, a beamz `<0.5` cap, and a
+documented `pip-audit` exception tracked in #115; no API change).
 It adds the interactive 3D viewer (`gds_fdtd.viewer3d.show_3d`), steerable and
 visible field monitors (`SimulationSpec.field_monitor_positions` /
 `field_monitor_wavelengths`, `plot_monitor_planes`), and two examples

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The version is derived **from git tags** via `hatch-vcs` — there is nothing to
 version string in the source. To release:
 
 ```bash
-git tag v0.6.1
+git tag v0.6.2
 git push --tags
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,10 +5,17 @@ should be able to read this, understand the current state, and pick up work
 without losing context. Keep it current; move granular tracking to GitHub
 Issues as items are picked up.
 
-## Where we are — v0.6.1 (released 2026-07-21)
+## Where we are — v0.6.2 (released 2026-08-04)
 
-`v0.6.1` is tagged with a signed GitHub release (Sigstore bundles + SBOM),
-building on `v0.6.0` (2026-07-15). It adds the interactive 3D viewer
+`v0.6.2` is a maintenance release over `v0.6.1`: dependency floors raised to
+current releases, a protective `beamz < 0.5` cap ahead of that project's
+breaking 0.5 API (#85), and a documented `pip-audit` exception for three
+`cryptography` advisories that cannot be remediated while tidy3d 2.12 pins
+`cryptography==48.0.1` (#115). No API change.
+
+`v0.6.1` (2026-07-21) is the feature release beneath it, tagged with a signed
+GitHub release (Sigstore bundles + SBOM) and building on `v0.6.0`
+(2026-07-15). It adds the interactive 3D viewer
 (`viewer3d.show_3d` / `save_3d` / `render_static`), steerable field monitors
 (`field_monitor_positions` / `field_monitor_wavelengths`, `plot_monitor_planes`),
 and examples `05b_field_monitors` + `11_bragg_grating`; it hardens the viewer
@@ -136,7 +143,7 @@ Not committed; a palette to choose from. Roughly ordered by impact.
       lands, tagged releases produce signed GitHub artifacts but the PyPI
       publish step cannot run (re-verified 2026-07-21: `invalid-publisher`,
       PyPI still serves 0.4.0). Once registered, re-run the failed publish job
-      of the latest (v0.6.1) Release run.
+      of the latest (v0.6.2) Release run.
 - [ ] **OpenSSF Best Practices badge** — register at bestpractices.dev.
 - [ ] **`cloud-tests` environment** with a required reviewer (guards the
       budget-gated tidy3d smoke).

--- a/SOLVER_STATUS.md
+++ b/SOLVER_STATUS.md
@@ -15,6 +15,15 @@ asserted every PR by `test_three_engine_agreement`).
 | Lumerical FDTD | 2026-07-13 | 2025 R2 (v252) | PBS + PSR full polarization matrices on local license (PSR: 10.9 h); S-bend convergence + injected-mode overlay within **0.03 dB** of tidy3d (`examples/06`); escalator full matrix; artifacts replayed every PR |
 | beamz | 2026-07-15 | 0.4.3 | slow-marked real end-to-end straight run executes in the CI all-extras leg on every PR (thru > −0.5 dB, reflections < −15 dB, reciprocity); beamz examples (`00`/`03`/`06`/`08`/`10`) executed 2026-07-14 |
 
+**tidy3d version note (0.6.2):** the `tidy3d` extra now floors at **2.12.0**,
+but the live cloud evidence in the table above was gathered on **2.11.2** — the
+dates and FlexCredit costs are unchanged and should not be read as a 2.12 live
+validation. What *was* checked on 2.12.0 is the offline half: the tidy3d-facing
+suites pass (25 passed, 1 skipped) and a real scene builds correctly against it
+(modeler construction, media, and the 0.6.1 monitor controls — pinned plane
+position and single recorded wavelength). The cloud `run()` path on 2.12.0 is
+still unexercised; the next `cloud-smoke` run is what refreshes this row.
+
 Refresh procedure: `cloud-smoke` workflow (tidy3d, budget-gated, human
 approval), `lumerical-nightly` workflow (self-hosted lane, see
 `docs/self_hosted_runner.md`), the beamz examples (`00_quickstart`,


### PR DESCRIPTION
Release prep for **v0.6.2**, plus the docs/changelog updates that go with it.

**Why 0.6.2 and not 0.7.0:** everything since v0.6.1 is dependency and CI maintenance — no new API, no behavioural change to the package. Code written against 0.6.1 keeps working, so a patch bump is the honest label.

### What's in it
- **Dependency floors** raised to current releases with `uv.lock` re-synced: tidy3d 2.12.0, gdsfactory 9.45.0, klayout 0.30.10, matplotlib 3.11.1, PyYAML 6.0.3, prefab 1.6.0; dev pytest 9.1.1, pytest-cov 7.1.0, ruff 0.16.1, hypothesis 6.164.0, h5py 3.16.0, build 1.5.0, pip 26.2; docs myst-nb 1.4.0, furo 2025.12.19.
- **`beamz < 0.5` cap** ahead of that project's breaking 0.5 API (#85).
- **Actions bumped**, including three majors checked against how we use them rather than by version number: `build-and-inspect` v3 (verified the `Packages` artifact contract is byte-identical, since `release.yml` downloads by that name), `download-artifact` v8, `prek-action` v3 and `setup-uv` v9.

### Security
`pip-audit` began failing on three fresh `cryptography` advisories — **CVE-2026-69247 (high)**, a Bleichenbacher oracle in PKCS#7 EnvelopedData decryption, plus CVE-2026-69248/69249. They cannot be fixed downstream: **tidy3d 2.12.0 pins `cryptography==48.0.1` exactly**, and re-locking under a `cryptography>=50` constraint reports the requirements as unsatisfiable.

The ids are ignored explicitly in the audit job (merged in #116) with reasoning inline and exit criteria in **#115**. Reachability was checked, not assumed: authlib 1.7.2 and tidy3d 2.12.0 each contain **zero** references to `cryptography...serialization.pkcs7`, and gds_fdtd never imports `cryptography`. Every other advisory still fails the job. This PR sharpens the workflow comment to name the PKCS#7 API precisely (my first pass said "authlib's JWT handling", which was imprecise).

### Docs
`SOLVER_STATUS.md` now states plainly that the tidy3d floor moved to 2.12.0 **while the live cloud evidence remains 2.11.2** — with the offline 2.12 verification (suites green, real scene build) recorded as exactly that, not as a live validation. README/HANDOFF/ROADMAP updated to 0.6.2.

Gates: ruff + format + `mypy --strict` clean, **397 passed**, 90.22% branch coverage, sphinx build clean. Tagging `v0.6.2` once this merges.
