### PR TITLE
release: v0.6.3 - dependency and CI maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-08-04
+
+Maintenance release: dependency floors and pinned GitHub Actions moved to
+current releases. No API or behavioural change to the package — code written
+against 0.6.2 keeps working.
+
+### Changed
+- Dependency floors raised, with `uv.lock` re-synced:
+  - runtime: pydantic-settings >= 2.15.0
+  - dev: ruff >= 0.16.3, hypothesis >= 6.165.10, pip >= 26.2.1
+- Pinned GitHub Actions bumped: `setup-uv` v10.0.1 and
+  `codeql-action/upload-sarif` 4.37.7.
+  `setup-uv` v10 disables the cache by default for `pull_request_target`,
+  `workflow_run` and `release` events as cache-poisoning protection; that is a
+  no-op here, since the workflows that care set `enable-cache` explicitly
+  (`true` in CI, `false` in the publishing job) and none of those three
+  triggers is used in this repository.
+
+### Security
+- The `pip-audit` exception for the three `cryptography` advisories
+  (CVE-2026-69247 high, plus 69248/69249) documented in 0.6.2 still stands:
+  tidy3d remains at 2.12.0, which pins `cryptography==48.0.1` exactly, so the
+  exit criteria in #115 are not yet met. Re-checked at release time rather
+  than assumed. The vulnerable PKCS#7 API remains unreferenced by authlib,
+  tidy3d and this package.
+
 ## [0.6.2] - 2026-08-04
 
 Maintenance release: dependency floors, a protective cap on beamz, and a

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -6,13 +6,15 @@ the compressed history and the working conventions; the live plan is
 [`SOLVER_STATUS.md`](SOLVER_STATUS.md), and user-facing docs live at
 <https://siepic.github.io/gds_fdtd/>.
 
-**State:** `v0.6.2` is released (tagged 2026-08-04, signed GitHub release) — a
-maintenance release over `v0.6.1` (dependency floors, a beamz `<0.5` cap, and a
-documented `pip-audit` exception tracked in #115; no API change).
-It adds the interactive 3D viewer (`gds_fdtd.viewer3d.show_3d`), steerable and
-visible field monitors (`SimulationSpec.field_monitor_positions` /
+**State:** `v0.6.3` is released (tagged 2026-08-04, signed GitHub release) — a
+maintenance release over `v0.6.2` (dependency floors and pinned GitHub Actions
+moved to current releases; no API change). `v0.6.2` before it carried the beamz
+`<0.5` cap and the documented `pip-audit` exception still tracked in #115.
+The feature content beneath these came in `v0.6.1` (2026-07-21): the
+interactive 3D viewer (`gds_fdtd.viewer3d.show_3d`), steerable and visible
+field monitors (`SimulationSpec.field_monitor_positions` /
 `field_monitor_wavelengths`, `plot_monitor_planes`), and two examples
-(`05b_field_monitors`, `11_bragg_grating`) on top of `v0.6.0` (2026-07-15).
+(`05b_field_monitors`, `11_bragg_grating`), on top of `v0.6.0` (2026-07-15).
 The three engines were validated **live** against each other during the 0.6
 arc — tidy3d ↔ Lumerical within 0.0033 dB, beamz within 0.052 dB on the
 identical job — and that agreement is locked into CI through recorded

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ show_3d(solver)   # notebooks + docs; save_3d(...) writes a shareable page
 
 | engine | execution | cost | install |
 |---|---|---|---|
-| [Tidy3D](https://github.com/flexcompute/tidy3d) >= 2.11 | cloud | FlexCredits | `pip install gds_fdtd[tidy3d]` |
+| [Tidy3D](https://github.com/flexcompute/tidy3d) >= 2.12 | cloud | FlexCredits | `pip install gds_fdtd[tidy3d]` |
 | Ansys Lumerical FDTD 2024/2025 | local | license | Lumerical install + `lumapi` on path |
 | [beamz](https://github.com/beamzorg/beamz) >= 0.4.3, < 0.5 | local (JAX, CPU/GPU) | free | `pip install gds_fdtd[beamz]` |
 
@@ -159,7 +159,7 @@ The version is derived **from git tags** via `hatch-vcs` — there is nothing to
 version string in the source. To release:
 
 ```bash
-git tag v0.6.2
+git tag v0.6.3
 git push --tags
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,9 +5,15 @@ should be able to read this, understand the current state, and pick up work
 without losing context. Keep it current; move granular tracking to GitHub
 Issues as items are picked up.
 
-## Where we are — v0.6.2 (released 2026-08-04)
+## Where we are — v0.6.3 (released 2026-08-04)
 
-`v0.6.2` is a maintenance release over `v0.6.1`: dependency floors raised to
+`v0.6.3` is a maintenance release over `v0.6.2`: dependency floors and pinned
+GitHub Actions moved to current releases (including `setup-uv` v10, whose new
+cache-poisoning default is a no-op here). No API change. The `pip-audit`
+exception from 0.6.2 still stands — tidy3d remains at 2.12.0, so #115's exit
+criteria are unmet.
+
+`v0.6.2` is the maintenance release beneath it, over `v0.6.1`: dependency floors raised to
 current releases, a protective `beamz < 0.5` cap ahead of that project's
 breaking 0.5 API (#85), and a documented `pip-audit` exception for three
 `cryptography` advisories that cannot be remediated while tidy3d 2.12 pins
@@ -143,7 +149,7 @@ Not committed; a palette to choose from. Roughly ordered by impact.
       lands, tagged releases produce signed GitHub artifacts but the PyPI
       publish step cannot run (re-verified 2026-07-21: `invalid-publisher`,
       PyPI still serves 0.4.0). Once registered, re-run the failed publish job
-      of the latest (v0.6.2) Release run.
+      of the latest (v0.6.3) Release run.
 - [ ] **OpenSSF Best Practices badge** — register at bestpractices.dev.
 - [ ] **`cloud-tests` environment** with a required reviewer (guards the
       budget-gated tidy3d smoke).

--- a/docs/solvers.rst
+++ b/docs/solvers.rst
@@ -55,7 +55,7 @@ Available engines
      - execution
      - cost
      - install
-   * - `Tidy3D <https://github.com/flexcompute/tidy3d>`_ >= 2.11
+   * - `Tidy3D <https://github.com/flexcompute/tidy3d>`_ >= 2.12
      - cloud
      - FlexCredits
      - ``pip install gds_fdtd[tidy3d]`` + ``TIDY3D_API_KEY``


### PR DESCRIPTION
Release prep for **v0.6.3**, covering the six dependency PRs merged today.

**Why 0.6.3:** main sat exactly at the v0.6.2 tag, so everything in this release is dependency and CI maintenance — no API, no behaviour change. Code written against 0.6.2 keeps working, so a patch bump is the honest label.

### What's in it
- **Floors raised** with `uv.lock` re-synced: `pydantic-settings >= 2.15.0` (the only runtime dep in the batch), plus dev `ruff >= 0.16.3`, `hypothesis >= 6.165.10`, `pip >= 26.2.1`.
- **Actions bumped**: `setup-uv` v10.0.1 and `codeql-action/upload-sarif` 4.37.7.

The two that warranted more than a version check:

- **setup-uv v10** (major): its breaking change disables the cache by default for `pull_request_target`, `workflow_run` and `release` events. Verified a no-op here on two independent grounds — the workflows that care set `enable-cache` explicitly (`true` in CI, `false` in the publishing job, so `auto` never applies), and none of those three triggers appears anywhere in `.github/workflows/`.
- **pydantic-settings 2.15** (runtime): three documented behaviour changes, each checked against `GdsFdtdSettings` — the `case_sensitive` change targets init-kwargs/config-file sources (we read the environment only), the new `IncompleteFieldDefinitionWarning` needs unresolved forward references (our fields are all concrete), and the stricter `ValidationError` path needs strict-annotated fields (we have none, and our `filterwarnings` is scoped to `DeprecationWarning`, not blanket-error).

### Docs corrections
Found while checking release accuracy: the README supported-solvers table **and** `docs/solvers.rst` both still advertised tidy3d **">= 2.11"** after the floor moved to 2.12.0 in 0.6.2. Both corrected. CHANGELOG/README/HANDOFF/ROADMAP updated to 0.6.3.

### Security
The `pip-audit` exception for the three `cryptography` advisories (#115) was **re-checked rather than carried forward on faith**: tidy3d is still 2.12.0, so its exact `cryptography==48.0.1` pin stands and the exit criteria remain unmet. The ignores stay, and the release notes say so explicitly instead of letting the exception drift silently.

Gates: ruff + format + `mypy --strict` clean, **397 passed**, 90.22% branch coverage, sphinx build clean. Tagging `v0.6.3` once this merges.
